### PR TITLE
Add tracing to rb service

### DIFF
--- a/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud</groupId>
+      <artifactId>activiti-cloud-services-tracing</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.cloud</groupId>
       <artifactId>activiti-cloud-services-events</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Name of branch is wrong: should contain tracing and not monitoring. Sorry.