### PR TITLE
Create dedicated channels for integration requests

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
@@ -81,4 +81,47 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-assertions</goal>
+            </goals>
+          </execution>
+        </executions>
+
+        <configuration>
+
+          <packages>
+            <package>org.activiti.services.connectors.model</package>
+            <package>org.activiti.engine.impl.persistence.entity.integration</package>
+          </packages>
+
+          <!-- whether generated assertions classes can be inherited with consistent assertion chaining -->
+          <hierarchical>true</hierarchical>
+
+          <!-- where to generate assertions entry point classes -->
+          <entryPointClassPackage>${generated-assertions-package}</entryPointClassPackage>
+
+          <targetDir>${generated-assertions-folder}</targetDir>
+          <generateAssertions>true</generateAssertions>
+          <generateBddAssertions>false</generateBddAssertions>
+          <generateSoftAssertions>false</generateSoftAssertions>
+          <generateJUnitSoftAssertions>false</generateJUnitSoftAssertions>
+
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
@@ -1,50 +1,42 @@
 package org.activiti.services.connectors;
 
-import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.cloud.services.api.events.ProcessEngineEvent;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.integration.IntegrationRequestSentEventImpl;
-import org.activiti.engine.delegate.DelegateExecution;
-import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.activiti.services.connectors.model.IntegrationRequestEvent;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
-public class IntegrationRequestSender extends TransactionSynchronizationAdapter {
+@Component
+public class IntegrationRequestSender {
 
     protected static final String CONNECTOR_TYPE = "connectorType";
-    private final MessageChannel integrationEventsProducer;
     private final RuntimeBundleProperties runtimeBundleProperties;
     private final MessageChannel auditProducer;
-    private final IntegrationContextEntity integrationContextEntity;
-    private final DelegateExecution execution;
+    private final BinderAwareChannelResolver resolver;
 
-    public IntegrationRequestSender(MessageChannel integrationEventsProducer,
-                                    RuntimeBundleProperties runtimeBundleProperties,
+    public IntegrationRequestSender(RuntimeBundleProperties runtimeBundleProperties,
                                     MessageChannel auditProducer,
-                                    IntegrationContextEntity integrationContextEntity,
-                                    DelegateExecution execution) {
-        this.integrationEventsProducer = integrationEventsProducer;
+                                    BinderAwareChannelResolver resolver) {
         this.runtimeBundleProperties = runtimeBundleProperties;
         this.auditProducer = auditProducer;
-        this.integrationContextEntity = integrationContextEntity;
-        this.execution = execution;
+        this.resolver = resolver;
     }
 
-    @Override
-    public void afterCommit() {
-        Message<IntegrationRequestEvent> message = buildIntegrationRequestMessage(execution,
-                                                                                  integrationContextEntity);
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendIntegrationRequest(IntegrationRequestEvent event) {
 
-        integrationEventsProducer.send(message);
-        sendIntegrationRequestSentEvent(message);
+        resolver.resolveDestination(event.getConnectorType()).send(buildIntegrationRequestMessage(event));
+        sendAuditEvent(event);
     }
 
-    private void sendIntegrationRequestSentEvent(Message<IntegrationRequestEvent> message) {
+    private void sendAuditEvent(IntegrationRequestEvent integrationRequestEvent) {
         if (runtimeBundleProperties.getEventsProperties().isIntegrationAuditEventsEnabled()) {
-            IntegrationRequestEvent integrationRequestEvent = message.getPayload();
             IntegrationRequestSentEventImpl event = new IntegrationRequestSentEventImpl(runtimeBundleProperties.getName(),
                                                                                         integrationRequestEvent.getExecutionId(),
                                                                                         integrationRequestEvent.getProcessDefinitionId(),
@@ -57,19 +49,10 @@ public class IntegrationRequestSender extends TransactionSynchronizationAdapter 
         }
     }
 
-    private Message<IntegrationRequestEvent> buildIntegrationRequestMessage(DelegateExecution execution,
-                                                                            IntegrationContextEntity integrationContext) {
-        IntegrationRequestEvent event = new IntegrationRequestEvent(execution.getProcessInstanceId(),
-                                                                    execution.getProcessDefinitionId(),
-                                                                    integrationContext.getExecutionId(),
-                                                                    integrationContext.getId(),
-                                                                    integrationContext.getFlowNodeId(),
-                                                                    execution.getVariables());
-
-        String implementation = ((ServiceTask) execution.getCurrentFlowElement()).getImplementation();
+    private Message<IntegrationRequestEvent> buildIntegrationRequestMessage(IntegrationRequestEvent event) {
         return MessageBuilder.withPayload(event)
                 .setHeader(CONNECTOR_TYPE,
-                           implementation)
+                           event.getConnectorType())
                 .build();
     }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ProcessEngineIntegrationChannels.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ProcessEngineIntegrationChannels.java
@@ -17,8 +17,6 @@
 package org.activiti.services.connectors.channel;
 
 import org.springframework.cloud.stream.annotation.Input;
-import org.springframework.cloud.stream.annotation.Output;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 
 public interface ProcessEngineIntegrationChannels {
@@ -27,8 +25,5 @@ public interface ProcessEngineIntegrationChannels {
 
     @Input(INTEGRATION_RESULTS_CONSUMER)
     SubscribableChannel integrationResultsConsumer();
-
-    @Output("integrationEventsProducer")
-    MessageChannel integrationEventsProducer();
 
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/model/IntegrationRequestEvent.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/model/IntegrationRequestEvent.java
@@ -21,6 +21,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class IntegrationRequestEvent {
@@ -37,6 +40,10 @@ public class IntegrationRequestEvent {
 
     private String flowNodeId;
 
+    private String connectorType;
+
+    private String applicationName;
+
     private Map<String, Object> variables;
 
     //used by json deserialization
@@ -44,20 +51,20 @@ public class IntegrationRequestEvent {
         this.id = UUID.randomUUID().toString();
     }
 
-    public IntegrationRequestEvent(String processInstanceId,
-                                   String processDefinitionId,
-                                   String executionId,
-                                   String integrationContextId,
-                                   String flowNodeId,
-                                   Map<String, Object> variables) {
+    public IntegrationRequestEvent(DelegateExecution execution,
+                                   IntegrationContextEntity integrationContext,
+                                   String applicationName) {
         this();
-        this.processInstanceId = processInstanceId;
-        this.processDefinitionId = processDefinitionId;
-        this.executionId = executionId;
-        this.flowNodeId = flowNodeId;
-        this.variables = variables;
-        this.integrationContextId = integrationContextId;
+        this.processInstanceId = execution.getProcessInstanceId();
+        this.processDefinitionId = execution.getProcessDefinitionId();
+        this.executionId = integrationContext.getExecutionId();
+        this.flowNodeId = integrationContext.getFlowNodeId();
+        this.variables = execution.getVariables();
+        this.integrationContextId = integrationContext.getId();
+        this.applicationName = applicationName;
+        this.connectorType = ((ServiceTask) execution.getCurrentFlowElement()).getImplementation();
     }
+
 
     public String getId() {
         return id;
@@ -81,6 +88,14 @@ public class IntegrationRequestEvent {
 
     public String getFlowNodeId() {
         return flowNodeId;
+    }
+
+    public String getConnectorType() {
+        return connectorType;
+    }
+
+    public String getApplicationName() {
+        return applicationName;
     }
 
     public Map<String, Object> getVariables() {

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/test/DelegateExecutionBuilder.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/test/DelegateExecutionBuilder.java
@@ -48,6 +48,11 @@ public class DelegateExecutionBuilder {
             return this;
         }
 
+        public DelegateExecutionBuilder withFlowNodeId(String flowNodeId) {
+            when(execution.getCurrentActivityId()).thenReturn(flowNodeId);
+            return this;
+        }
+
         public DelegateExecutionBuilder withServiceTask(ServiceTask serviceTask) {
             when(execution.getCurrentFlowElement()).thenReturn(serviceTask);
             return this;

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -35,9 +35,7 @@ public class ServiceTaskConsumerHandler {
     @Autowired
     private ConnectorIntegrationChannels consumerChannels;
 
-    @StreamListener(
-            value = ConnectorIntegrationChannels.INTEGRATION_EVENTS_CONSUMER,
-            condition = "headers['connectorType']=='payment'")
+    @StreamListener(value = ConnectorIntegrationChannels.INTEGRATION_EVENTS_CONSUMER)
     public void receive(IntegrationRequestEvent integrationRequestEvent) {
         Map<String, Object> requestVariables = integrationRequestEvent.getVariables();
         String variableToUpdate = "age";

--- a/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -12,11 +12,8 @@ spring.cloud.stream.bindings.auditConsumer.destination=engineEvents
 spring.cloud.stream.bindings.auditConsumer.group=audit
 spring.cloud.stream.bindings.auditConsumer.contentType=application/json
 
-#Activiti engine producer (send integration request)
-spring.cloud.stream.bindings.integrationEventsProducer.destination=integration
-spring.cloud.stream.bindings.integrationEventsProducer.contentType=application/json
 # connector subscriber (receive integration request)
-spring.cloud.stream.bindings.integrationEventsConsumer.destination=integration
+spring.cloud.stream.bindings.integrationEventsConsumer.destination=payment
 spring.cloud.stream.bindings.integrationEventsConsumer.group=integration
 spring.cloud.stream.bindings.integrationEventsConsumer.contentType=application/json
 


### PR DESCRIPTION
- use dynamic bound destination based on the service task implementation
- use @TransactionalEventListener to send messages only when the transaction has been committed
- refers to https://github.com/Activiti/Activiti/issues/1680