### PR TITLE
Send integration results only to the target runtime bundle

### DIFF
--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ConnectorIntegrationChannels.java
@@ -17,8 +17,6 @@
 package org.activiti.cloud.starter.tests.runtime;
 
 import org.springframework.cloud.stream.annotation.Input;
-import org.springframework.cloud.stream.annotation.Output;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 
 public interface ConnectorIntegrationChannels {
@@ -27,8 +25,5 @@ public interface ConnectorIntegrationChannels {
 
     @Input(INTEGRATION_EVENTS_CONSUMER)
     SubscribableChannel integrationEventsConsumer();
-
-    @Output("integrationResultsProducer")
-    MessageChannel integrationResultsProducer();
 
 }

--- a/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -17,11 +17,8 @@ spring.cloud.stream.bindings.integrationEventsConsumer.destination=payment
 spring.cloud.stream.bindings.integrationEventsConsumer.group=integration
 spring.cloud.stream.bindings.integrationEventsConsumer.contentType=application/json
 
-# connector producer (send integration result)
-spring.cloud.stream.bindings.integrationResultsProducer.destination=integrationResult
-spring.cloud.stream.bindings.integrationResultsProducer.contentType=application/json
 # Activiti engine subscriber (receive integration result)
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}
 spring.cloud.stream.bindings.integrationResultsConsumer.group=integrationResult
 spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
 


### PR DESCRIPTION
Use dynamic bound destinations to send integration requests only to the target runtime bundle:
- each integration request will bring the information about the source application name
- the target channel will be `IntegrationResult:<applicationName>`
- each runtime bundle should configure the `integrationResultsConsumer` channel as following:
`spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}`