### PR TITLE
Create default configuration for Integration Result channel bindings

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/application.properties
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/config/application.properties
@@ -1,0 +1,4 @@
+# Activiti engine subscriber (receive integration result)
+spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}
+spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
+spring.cloud.stream.bindings.integrationResultsConsumer.group=${ACT_RB_APP_NAME:my-runtime-bundle}

--- a/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
+++ b/activiti-cloud-starter-runtime-bundle/src/test/resources/application-test.properties
@@ -17,11 +17,6 @@ spring.cloud.stream.bindings.integrationEventsConsumer.destination=payment
 spring.cloud.stream.bindings.integrationEventsConsumer.group=integration
 spring.cloud.stream.bindings.integrationEventsConsumer.contentType=application/json
 
-# Activiti engine subscriber (receive integration result)
-spring.cloud.stream.bindings.integrationResultsConsumer.destination=integrationResult:${spring.application.name}
-spring.cloud.stream.bindings.integrationResultsConsumer.group=integrationResult
-spring.cloud.stream.bindings.integrationResultsConsumer.contentType=application/json
-
 activiti.keycloak.test-user=testuser
 activiti.keycloak.test-password=password
 


### PR DESCRIPTION
- default configuration is provided by the runtime bundle service to avoid redefining it on every runtime bundle