### PR TITLE
1812 Add REST APIs to delete a task

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/main/java/org/activiti/cloud/services/api/model/Task.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/main/java/org/activiti/cloud/services/api/model/Task.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class Task {
 
     public enum TaskStatus {
-                            CREATED, ASSIGNED, SUSPENDED
+        CREATED, ASSIGNED, SUSPENDED, CANCELLED
     }
 
     private String id;
@@ -40,7 +40,7 @@ public class Task {
     private String processDefinitionId;
     private String processInstanceId;
     private String parentTaskId;
-    private String status;
+    private TaskStatus status;
 
     public Task() {
     }
@@ -57,7 +57,7 @@ public class Task {
                 String processDefinitionId,
                 String processInstanceId,
                 String parentTaskId,
-                String status) {
+                TaskStatus status) {
         this.id = id;
         this.owner = owner;
         this.assignee = assignee;
@@ -125,7 +125,7 @@ public class Task {
         return processInstanceId;
     }
 
-    public String getStatus() {
+    public TaskStatus getStatus() {
         return status;
     }
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/main/java/org/activiti/cloud/services/api/model/converter/TaskConverter.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/main/java/org/activiti/cloud/services/api/model/converter/TaskConverter.java
@@ -17,9 +17,16 @@ package org.activiti.cloud.services.api.model.converter;
 
 import java.util.List;
 
+import org.activiti.engine.impl.persistence.entity.TaskEntity;
 import org.activiti.engine.task.Task;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.activiti.cloud.services.api.model.Task.TaskStatus;
+
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.CREATED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.SUSPENDED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.CANCELLED;
 
 @Component
 public class TaskConverter implements ModelConverter<Task, org.activiti.cloud.services.api.model.Task> {
@@ -52,13 +59,16 @@ public class TaskConverter implements ModelConverter<Task, org.activiti.cloud.se
         return task;
     }
 
-    private String calculateStatus(Task source) {
-        if (source.isSuspended()) {
-            return org.activiti.cloud.services.api.model.Task.TaskStatus.SUSPENDED.name();
+    private TaskStatus calculateStatus(Task source) {
+        if (source instanceof TaskEntity &&
+                (((TaskEntity) source).isDeleted() || ((TaskEntity) source).isCanceled())) {
+            return CANCELLED;
+        } else if (source.isSuspended()) {
+            return SUSPENDED;
         } else if (source.getAssignee() != null && !source.getAssignee().isEmpty()) {
-            return org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED.name();
+            return ASSIGNED;
         }
-        return org.activiti.cloud.services.api.model.Task.TaskStatus.CREATED.name();
+        return CREATED;
     }
 
     @Override

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/test/java/org/activiti/cloud/services/api/converter/MockTaskBuilder.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/test/java/org/activiti/cloud/services/api/converter/MockTaskBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.api.converter;
+
+import java.util.Date;
+
+import org.activiti.engine.impl.persistence.entity.TaskEntity;
+import org.activiti.engine.task.Task;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Mock task builder
+ */
+public class MockTaskBuilder {
+
+    private Task task;
+
+    private MockTaskBuilder(Class<? extends Task> taskClass) {
+        task = mock(taskClass);
+    }
+
+    public static MockTaskBuilder taskBuilder() {
+        return new MockTaskBuilder(Task.class);
+    }
+
+    public static MockTaskBuilder taskEntityBuilder() {
+        return new MockTaskBuilder(TaskEntity.class);
+    }
+
+    public MockTaskBuilder withId(String id) {
+        when(task.getId()).thenReturn(id);
+        return this;
+    }
+
+    public MockTaskBuilder withOwner(String owner) {
+        when(task.getOwner()).thenReturn(owner);
+        return this;
+    }
+
+    public MockTaskBuilder withAssignee(String assignee) {
+        when(task.getAssignee()).thenReturn(assignee);
+        return this;
+    }
+
+    public MockTaskBuilder withName(String name) {
+        when(task.getName()).thenReturn(name);
+        return this;
+    }
+
+    public MockTaskBuilder withDescription(String description) {
+        when(task.getDescription()).thenReturn(description);
+        return this;
+    }
+
+    public MockTaskBuilder withCreatedDate(Date createdDate) {
+        when(task.getCreateTime()).thenReturn(createdDate);
+        return this;
+    }
+
+    public MockTaskBuilder withClaimedDate(Date claimedDate) {
+        when(task.getClaimTime()).thenReturn(claimedDate);
+        return this;
+    }
+
+    public MockTaskBuilder withDueDate(Date dueDate) {
+        when(task.getDueDate()).thenReturn(dueDate);
+        return this;
+    }
+
+    public MockTaskBuilder withPriority(int priority) {
+        when(task.getPriority()).thenReturn(priority);
+        return this;
+    }
+
+    public MockTaskBuilder withProcessDefinitionId(String processDefinitionId) {
+        when(task.getProcessDefinitionId()).thenReturn(processDefinitionId);
+        return this;
+    }
+
+    public MockTaskBuilder withProcessInstanceId(String processInstanceId) {
+        when(task.getProcessInstanceId()).thenReturn(processInstanceId);
+        return this;
+    }
+
+    public MockTaskBuilder withParentTaskId(String parentTaskId) {
+        when(task.getParentTaskId()).thenReturn(parentTaskId);
+        return this;
+    }
+
+    public MockTaskBuilder withSuspended(boolean suspended) {
+        when(task.isSuspended()).thenReturn(suspended);
+        return this;
+    }
+
+    public MockTaskBuilder withCancalled(boolean cancelled) {
+        if (task instanceof TaskEntity) {
+            when(((TaskEntity) task).isCanceled()).thenReturn(cancelled);
+        }
+        return this;
+    }
+
+    public MockTaskBuilder withDeleted(boolean deleted) {
+        if (task instanceof TaskEntity) {
+            when(((TaskEntity) task).isDeleted()).thenReturn(deleted);
+        }
+        return this;
+    }
+
+    public Task build() {
+        return task;
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/test/java/org/activiti/cloud/services/api/converter/TaskConverterTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-api/src/test/java/org/activiti/cloud/services/api/converter/TaskConverterTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.api.converter;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.activiti.cloud.services.api.model.Task;
+import org.activiti.cloud.services.api.model.converter.ListConverter;
+import org.activiti.cloud.services.api.model.converter.TaskConverter;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.activiti.cloud.services.api.converter.MockTaskBuilder.taskBuilder;
+import static org.activiti.cloud.services.api.converter.MockTaskBuilder.taskEntityBuilder;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.CANCELLED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.CREATED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.SUSPENDED;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests for {@link TaskConverter}
+ */
+public class TaskConverterTest {
+
+    private TaskConverter taskConverter;
+
+    @Before
+    public void setUp() {
+        taskConverter = new TaskConverter(new ListConverter());
+    }
+
+    /**
+     * Test that all task fields are present in the converted task
+     */
+    @Test
+    public void testConvertFromTask() {
+        //WHEN
+        Date now = new Date();
+        Task convertedTask = taskConverter.from(
+                taskBuilder()
+                        .withId("testTaskId")
+                        .withAssignee("testUser")
+                        .withName("testTaskName")
+                        .withDescription("testTaskDescription")
+                        .withCreatedDate(now)
+                        .withClaimedDate(now)
+                        .withDueDate(now)
+                        .withPriority(112)
+                        .withProcessDefinitionId("testProcessDefinitionId")
+                        .withProcessInstanceId("testProcessInstanceId")
+                        .withParentTaskId("testParentTaskId")
+                        .build()
+        );
+
+        //THEN
+        assertThat(convertedTask)
+                .isNotNull()
+                .extracting(Task::getId,
+                            Task::getAssignee,
+                            Task::getName,
+                            Task::getDescription,
+                            Task::getCreatedDate,
+                            Task::getClaimedDate,
+                            Task::getDueDate,
+                            Task::getPriority,
+                            Task::getProcessDefinitionId,
+                            Task::getProcessInstanceId,
+                            Task::getParentTaskId,
+                            Task::getStatus)
+                .containsExactly("testTaskId",
+                                 "testUser",
+                                 "testTaskName",
+                                 "testTaskDescription",
+                                 now,
+                                 now,
+                                 now,
+                                 112,
+                                 "testProcessDefinitionId",
+                                 "testProcessInstanceId",
+                                 "testParentTaskId",
+                                 ASSIGNED);
+    }
+
+    /**
+     * Test that all tasks from a list are converted when dedicated from() method id used
+     */
+    @Test
+    public void testConvertFromTasksList() {
+        //WHEN
+        List<Task> convertedTasks = taskConverter.from(Arrays.asList(
+                taskEntityBuilder().withId("testTaskId1").build(),
+                taskEntityBuilder().withId("testTaskId2").build()
+        ));
+
+        //THEN
+        assertThat(convertedTasks)
+                .isNotEmpty()
+                .extracting(Task::getId)
+                .containsExactly("testTaskId1",
+                                 "testTaskId2");
+    }
+
+    /**
+     * Test that computed status for a cancelled task is CANCELLED
+     */
+    @Test
+    public void testCalculateStatusCancelledTask() {
+        assertThat(taskConverter.from(taskEntityBuilder().withCancalled(true).build()))
+                .isNotNull()
+                .extracting(Task::getStatus)
+                .containsExactly(CANCELLED);
+    }
+
+    /**
+     * Test that computed status for a suspended task is SUSPENDED
+     */
+    @Test
+    public void testCalculateStatusSuspendedTask() {
+        assertThat(taskConverter.from(taskEntityBuilder().withSuspended(true).build()))
+                .isNotNull()
+                .extracting(Task::getStatus)
+                .containsExactly(SUSPENDED);
+    }
+
+    /**
+     * Test that computed status for a assigned task is ASSIGNED
+     */
+    @Test
+    public void testCalculateStatusAssignedTask() {
+        assertThat(taskConverter.from(taskBuilder().withAssignee("testUser").build()))
+                .isNotNull()
+                .extracting(Task::getStatus)
+                .containsExactly(ASSIGNED);
+    }
+
+    /**
+     * Test that computed status for a not assigned task is CREATED
+     */
+    @Test
+    public void testCalculateStatusCreatedTask() {
+        assertThat(taskConverter.from(taskBuilder().build()))
+                .isNotNull()
+                .extracting(Task::getStatus)
+                .containsExactly(CREATED);
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessEngineWrapper.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessEngineWrapper.java
@@ -200,6 +200,26 @@ public class ProcessEngineWrapper {
                                       setTaskVariablesCmd.getVariables());
     }
 
+    /**
+     * Delete task by id.
+     * @param taskId the task id to delete
+     */
+    public void deleteTask(String taskId) {
+        Task task = getTaskById(taskId);
+        if (task == null) {
+            throw new ActivitiObjectNotFoundException("Unable to find task for the given id: " + taskId);
+        }
+
+        checkWritePermissionsOnTask(task);
+
+        taskService.deleteTask(taskId,
+                               "Cancelled by " + authenticationWrapper.getAuthenticatedUserId());
+    }
+
+    public void checkWritePermissionsOnTask(Task task) {
+        //TODO: to check the user write permissions on task
+    }
+
     public Task createNewTask(CreateTaskCmd createTaskCmd) {
         final org.activiti.engine.task.Task task = taskService.newTask();
         task.setName(createTaskCmd.getName());

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/TaskCancelledEventImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/TaskCancelledEventImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.events;
+
+import org.activiti.cloud.services.api.model.Task;
+
+/**
+ * Task cancelled event implementation
+ */
+public class TaskCancelledEventImpl extends AbstractProcessEngineEvent {
+
+    private Task task;
+
+    public TaskCancelledEventImpl() {
+    }
+
+    public TaskCancelledEventImpl(String applicationName,
+                                  String executionId,
+                                  String processDefinitionId,
+                                  String processInstanceId,
+                                  Task task) {
+        super(applicationName,
+              executionId,
+              processDefinitionId,
+              processInstanceId);
+        this.task = task;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    @Override
+    public String getEventType() {
+        return "TaskCancelledEvent";
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/converter/TaskCancelledEventConverter.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/converter/TaskCancelledEventConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.events.converter;
+
+import org.activiti.cloud.services.api.events.ProcessEngineEvent;
+import org.activiti.cloud.services.api.model.converter.TaskConverter;
+import org.activiti.cloud.services.events.TaskCancelledEventImpl;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.impl.ActivitiEntityEventImpl;
+import org.activiti.engine.task.Task;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static org.activiti.engine.delegate.event.ActivitiEventType.ENTITY_DELETED;
+
+/**
+ * Converter from ActivitiEvent to TaskCancelledEventImpl
+ */
+@Component
+public class TaskCancelledEventConverter extends AbstractEventConverter {
+
+    private final TaskConverter taskConverter;
+
+    @Autowired
+    public TaskCancelledEventConverter(TaskConverter taskConverter,
+                                       RuntimeBundleProperties runtimeBundleProperties) {
+        super(runtimeBundleProperties);
+        this.taskConverter = taskConverter;
+    }
+
+    @Override
+    public ProcessEngineEvent from(ActivitiEvent event) {
+        return new TaskCancelledEventImpl(getApplicationName(),
+                                          event.getExecutionId(),
+                                          event.getProcessDefinitionId(),
+                                          event.getProcessInstanceId(),
+                                          //TODO: to refactor using generics to avoid this cast
+                                          taskConverter.from((Task) ((ActivitiEntityEventImpl) event).getEntity()));
+    }
+
+    @Override
+    public String handledType() {
+        return "Task:" + ENTITY_DELETED.toString();
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/TaskCancelledEventImplTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/TaskCancelledEventImplTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.events;
+
+import org.activiti.cloud.services.api.events.ProcessEngineEvent;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests for {@link TaskCancelledEventImpl}
+ */
+public class TaskCancelledEventImplTest {
+
+    /**
+     * Test that the event type of TaskCancelledEventImpl is TaskCancelledEvent
+     */
+    @Test
+    public void getEventTypeShouldReturnTaskCancelledEvent() {
+        //given
+        ProcessEngineEvent event = new TaskCancelledEventImpl();
+
+        //when
+        String eventType = event.getEventType();
+
+        //then
+        assertThat(eventType).isEqualTo("TaskCancelledEvent");
+    }
+
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/EventConverterContextIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/EventConverterContextIT.java
@@ -73,6 +73,7 @@ public class EventConverterContextIT {
                                                            "Task:" + ActivitiEventType.TASK_ASSIGNED.toString(),
                                                            "Task:" + ActivitiEventType.TASK_COMPLETED.toString(),
                                                            "Task:" + ActivitiEventType.TASK_CREATED.toString(),
+                                                           "Task:" + ActivitiEventType.ENTITY_DELETED.toString(),
                                                            "TaskCandidateUser:" + ActivitiEventType.ENTITY_CREATED.toString(),
                                                            "TaskCandidateUser:" + ActivitiEventType.ENTITY_DELETED.toString(),
                                                            "TaskCandidateGroup:" + ActivitiEventType.ENTITY_CREATED.toString(),

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/TaskCancelledEventConverterTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/converter/TaskCancelledEventConverterTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.events.converter;
+
+import org.activiti.cloud.services.api.events.ProcessEngineEvent;
+import org.activiti.cloud.services.api.model.converter.TaskConverter;
+import org.activiti.cloud.services.events.TaskCancelledEventImpl;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiEntityEventImpl;
+import org.activiti.engine.task.Task;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.activiti.cloud.services.events.converter.EventConverterContext.getPrefix;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Tests for {@link TaskCancelledEventConverter}
+ */
+public class TaskCancelledEventConverterTest {
+
+    @InjectMocks
+    private TaskCancelledEventConverter taskCancelledEventConverter;
+
+    @Mock
+    private TaskConverter taskConverter;
+
+    @Mock
+    private RuntimeBundleProperties runtimeBundleProperties;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
+
+    /**
+     * Test that and ActivitiEntityEventImpl with ENTITY_DELETED type and entity of Task
+     * will be converted to TaskCancelledEventImpl
+     */
+    @Test
+    public void convertActivitiTaskEntityDeletedEventToTaskCancelledEventImpl() {
+        //given
+        ActivitiEntityEventImpl activitiEvent = mock(ActivitiEntityEventImpl.class);
+        given(activitiEvent.getType()).willReturn(ActivitiEventType.ENTITY_DELETED);
+        Task internalTask = mock(Task.class);
+        given(activitiEvent.getEntity()).willReturn(internalTask);
+
+        org.activiti.cloud.services.api.model.Task externalTask = mock(org.activiti.cloud.services.api.model.Task.class);
+        given(taskConverter.from(internalTask)).willReturn(externalTask);
+
+        given(runtimeBundleProperties.getName()).willReturn("myApp");
+
+        //when
+        ProcessEngineEvent pee = taskCancelledEventConverter.from(activitiEvent);
+
+        //then
+        assertThat(pee).isInstanceOf(TaskCancelledEventImpl.class);
+        assertThat(((TaskCancelledEventImpl) pee).getTask()).isEqualTo(externalTask);
+        assertThat(pee.getApplicationName()).isEqualTo("myApp");
+        assertThat(pee.getEventType()).isEqualTo("TaskCancelledEvent");
+    }
+
+    /**
+     * Test that TaskCancelledEventConverter handles "Task: ENTITY_DELETED" events type
+     */
+    @Test
+    public void handledTypeShouldReturnTaskCancelled() {
+        //when
+        ActivitiEntityEventImpl activitiEvent = mock(ActivitiEntityEventImpl.class);
+        given(activitiEvent.getType()).willReturn(ActivitiEventType.ENTITY_DELETED);
+        given(activitiEvent.getEntity()).willReturn(mock(Task.class));
+        //then
+        assertThat(taskCancelledEventConverter.handledType()).isEqualTo(getPrefix(activitiEvent) + ActivitiEventType.ENTITY_DELETED);
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/MessageProducerActivitiEventActivateSuspendIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/MessageProducerActivitiEventActivateSuspendIT.java
@@ -110,26 +110,6 @@ public class MessageProducerActivitiEventActivateSuspendIT {
         assertThat(events[1].getClass()).isEqualTo(TaskActivatedEventImpl.class);
     }
 
-    @Test
-    public void testActivitiEventsDeleteProcessInstance() throws Exception {
-        ProcessEngine processEngine = ProcessEngineConfiguration.createStandaloneInMemProcessEngineConfiguration()
-                .setDatabaseSchemaUpdate(ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_DROP_CREATE)
-                .buildProcessEngine();
-        deploy("SimpleUserTaskProcess",
-               processEngine);
-        processEngine.getRuntimeService().addEventListener(eventListener);
-
-        ProcessInstance processInstance =
-                processEngine.getRuntimeService().startProcessInstanceByKey("simpleUserTaskProcess");
-        processEngine.getRuntimeService().deleteProcessInstance(processInstance.getId(),
-                                                                "test");
-
-        ProcessEngineEvent[] events = (ProcessEngineEvent[]) MockMessageChannel.messageResult.getPayload();
-        assertThat(events.length).isEqualTo(2);
-        assertThat(events[0]).isInstanceOf(ActivityCancelledEventImpl.class);
-        assertThat(events[1]).isInstanceOf(ProcessCancelledEventImpl.class);
-    }
-
     public static void deploy(final String processDefinitionKey,
                               ProcessEngine processEngine) throws IOException {
         try (InputStream is = ClassLoader.getSystemResourceAsStream("processes/" + processDefinitionKey + ".bpmn")) {

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskController.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskController.java
@@ -34,6 +34,9 @@ public interface TaskController {
     ResponseEntity<Void> completeTask(@PathVariable String taskId,
                                       @RequestBody(required = false) CompleteTaskCmd completeTaskCmd);
 
+    @RequestMapping(value = "/{taskId}", method = RequestMethod.DELETE)
+    void deleteTask(@PathVariable String taskId);
+
     @RequestMapping(method = RequestMethod.POST)
     Resource<Task> createNewTask(@RequestBody CreateTaskCmd createTaskCmd);
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/TaskResourceAssembler.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/TaskResourceAssembler.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
 
 @Component
 public class TaskResourceAssembler extends ResourceAssemblerSupport<Task, TaskResource> {
@@ -42,7 +43,7 @@ public class TaskResourceAssembler extends ResourceAssemblerSupport<Task, TaskRe
     public TaskResource toResource(Task task) {
         List<Link> links = new ArrayList<>();
         links.add(linkTo(methodOn(TaskControllerImpl.class).getTaskById(task.getId())).withSelfRel());
-        if (!Task.TaskStatus.ASSIGNED.name().equals(task.getStatus())) {
+        if (ASSIGNED != task.getStatus()) {
             links.add(linkTo(methodOn(TaskControllerImpl.class).claimTask(task.getId())).withRel("claim"));
         } else {
             links.add(linkTo(methodOn(TaskControllerImpl.class).releaseTask(task.getId())).withRel("release"));

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskControllerImpl.java
@@ -28,6 +28,7 @@ import org.activiti.cloud.services.core.ProcessEngineWrapper;
 import org.activiti.cloud.services.rest.api.TaskController;
 import org.activiti.cloud.services.rest.api.resources.TaskResource;
 import org.activiti.cloud.services.rest.assemblers.TaskResourceAssembler;
+import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,8 +36,10 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -61,6 +64,12 @@ public class TaskControllerImpl implements TaskController {
         this.pagedResourcesAssembler = pagedResourcesAssembler;
     }
 
+    @ExceptionHandler(ActivitiObjectNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleAppException(ActivitiObjectNotFoundException ex) {
+        return ex.getMessage();
+    }
+
     @Override
     public PagedResources<TaskResource> getTasks(Pageable pageable) {
         Page<Task> page = processEngine.getTasks(pageable);
@@ -70,7 +79,11 @@ public class TaskControllerImpl implements TaskController {
 
     @Override
     public Resource<Task> getTaskById(@PathVariable String taskId) {
-        return taskResourceAssembler.toResource(processEngine.getTaskById(taskId));
+        Task task = processEngine.getTaskById(taskId);
+        if (task == null) {
+            throw new ActivitiObjectNotFoundException("Unable to find task for the given id: " + taskId);
+        }
+        return taskResourceAssembler.toResource(task);
     }
 
     @Override
@@ -103,15 +116,13 @@ public class TaskControllerImpl implements TaskController {
     }
 
     @Override
+    public void deleteTask(@PathVariable String taskId) {
+        processEngine.deleteTask(taskId);
+    }
+
+    @Override
     public Resource<Task> createNewTask(@RequestBody CreateTaskCmd createTaskCmd) {
         return taskResourceAssembler.toResource(processEngine.createNewTask(createTaskCmd));
     }
 
-    public AuthenticationWrapper getAuthenticationWrapper() {
-        return authenticationWrapper;
-    }
-    
-    public void setAuthenticationWrapper(AuthenticationWrapper authenticationWrapper) {
-        this.authenticationWrapper = authenticationWrapper;
-    }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/assemblers/TaskResourceAssemblerTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/assemblers/TaskResourceAssemblerTest.java
@@ -5,6 +5,8 @@ import org.activiti.cloud.services.rest.api.resources.TaskResource;
 import org.junit.Test;
 import org.springframework.hateoas.Link;
 
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.CREATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,7 +44,7 @@ public class TaskResourceAssemblerTest {
     public void toResourceShouldReturnResourceWithClaimLinkWhenStatusIsNotAssigned() {
         Task model = mock(Task.class);
         when(model.getId()).thenReturn("my-identifier");
-        when(model.getStatus()).thenReturn(Task.TaskStatus.ASSIGNED.name());
+        when(model.getStatus()).thenReturn(ASSIGNED);
 
         TaskResource resource = resourceAssembler.toResource(model);
 
@@ -54,7 +56,7 @@ public class TaskResourceAssemblerTest {
     @Test
     public void toResourceShouldNotReturnResourceWithProcessInstanceLinkWhenNewTaskIsCreated() {
         Task model = mock(Task.class);
-        when(model.getStatus()).thenReturn(Task.TaskStatus.CREATED.name());
+        when(model.getStatus()).thenReturn(CREATED);
         TaskResource resource = resourceAssembler.toResource(model);
 
         // a new standalone task doesn't have a bond to a process instance

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
@@ -40,6 +40,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.processInstanceIdParameter;
@@ -125,6 +126,6 @@ public class ProcessInstanceTasksControllerImplIT {
                         UUID.randomUUID().toString(),
                         UUID.randomUUID().toString(),
                         null,
-                        Task.TaskStatus.ASSIGNED.name());
+                        ASSIGNED);
     }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.activiti.cloud.services.api.model.Task;
+import org.activiti.cloud.services.api.model.Task.TaskStatus;
 import org.activiti.cloud.services.core.ProcessEngineWrapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +40,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
 import static org.mockito.Mockito.*;
@@ -99,11 +101,11 @@ public class TaskAdminControllerImplIT {
     }
 
     private Task buildDefaultTask() {
-        return buildTask(Task.TaskStatus.ASSIGNED, "user");
+        return buildTask(ASSIGNED, "user");
     }
 
 
-    private Task buildTask(Task.TaskStatus status,
+    private Task buildTask(TaskStatus status,
                            String assignee) {
         return new Task(UUID.randomUUID().toString(),
                         "user",
@@ -117,7 +119,7 @@ public class TaskAdminControllerImplIT {
                         UUID.randomUUID().toString(),
                         UUID.randomUUID().toString(),
                         null,
-                        status.name());
+                        status);
     }
 
 }

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -50,6 +50,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.ASSIGNED;
+import static org.activiti.cloud.services.api.model.Task.TaskStatus.CREATED;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
 
@@ -126,7 +128,7 @@ public class CommandEndpointIT {
         assertThat(responseEntity).isNotNull();
         Collection<Task> tasks = responseEntity.getBody().getContent();
         assertThat(tasks).extracting(Task::getName).contains("Perform action");
-        assertThat(tasks).extracting(Task::getStatus).contains(Task.TaskStatus.CREATED.name());
+        assertThat(tasks).extracting(Task::getStatus).contains(CREATED);
 
         Task task = tasks.iterator().next();
 
@@ -188,7 +190,7 @@ public class CommandEndpointIT {
         await("task to be released").untilTrue(streamHandler.getReleasedTaskAck());
 
         assertThatTaskHasStatus(task.getId(),
-                                Task.TaskStatus.CREATED);
+                                CREATED);
     }
 
     private void claimTask(Task task) throws InterruptedException {
@@ -201,7 +203,7 @@ public class CommandEndpointIT {
         await("task to be claimed").untilTrue(streamHandler.getClaimedTaskAck());
 
         assertThatTaskHasStatus(task.getId(),
-                                Task.TaskStatus.ASSIGNED
+                                ASSIGNED
         );
     }
 
@@ -209,7 +211,7 @@ public class CommandEndpointIT {
                                          Task.TaskStatus status) {
         ResponseEntity<Task> responseEntity = getTask(taskId);
         Task retrievedTask = responseEntity.getBody();
-        assertThat(retrievedTask.getStatus()).isEqualTo(status.name());
+        assertThat(retrievedTask.getStatus()).isEqualTo(status);
     }
 
     private void activateProcessInstance(String processDefinitionId,


### PR DESCRIPTION
- fix getTaskById() to throw ResourceNotFoundException when not found
- add "DELETE /v1/tasks/{taskId}" endpont
- add tests for endpoint and service method
- handle engine ENTITY_DDELETED event
- add tests for event hendler
- use TaskStatus enum instead String in Task model
- add tests for TaskConverter

https://github.com/Activiti/Activiti/issues/1812