### PR TITLE
Make tests compatible with Spring Booot 2.0.4.RELEASE

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
@@ -47,7 +47,6 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -61,10 +60,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
 import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
@@ -105,7 +106,7 @@ public class ProcessInstanceControllerImplIT {
     @MockBean
     private ProcessDiagramGeneratorWrapper processDiagramGenerator;
 
-    @SpyBean
+    @Autowired
     private ObjectMapper mapper;
 
     @MockBean

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
@@ -83,7 +83,7 @@ public class ProcessInstanceVariableControllerImplIT {
     @MockBean
     private SecurityAwareProcessInstanceService securityAwareProcessInstanceService;
 
-    @SpyBean
+    @Autowired
     private ObjectMapper mapper;
 
     @SpyBean

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
@@ -40,6 +40,7 @@ import org.activiti.runtime.conf.TaskModelAutoConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -96,7 +97,7 @@ public class TaskControllerImplIT {
     @Autowired
     private MockMvc mockMvc;
 
-    @SpyBean
+    @Autowired
     private ObjectMapper mapper;
 
     @MockBean
@@ -110,6 +111,9 @@ public class TaskControllerImplIT {
 
     @MockBean
     private ProcessEngineChannels processEngineChannels;
+
+    @Mock
+    private Page<Task> taskPage;
 
     @Before
     public void setUp() {
@@ -305,10 +309,9 @@ public class TaskControllerImplIT {
 
         final TaskImpl subtask2 = buildTask("subtask-2",
                                             "subtask-2 description");
-        Page page = mock(Page.class);
-        when(page.getContent()).thenReturn(Arrays.asList(subtask1,
+        when(taskPage.getContent()).thenReturn(Arrays.asList(subtask1,
                                                          subtask2));
-        when(securityAwareTaskService.tasks(any(), any())).thenReturn(page);
+        when(securityAwareTaskService.tasks(any(), any())).thenReturn(taskPage);
 
         this.mockMvc.perform(get("/v1/tasks/{taskId}/subtasks",
                                  "parentTaskId").contentType(MediaType.APPLICATION_JSON))

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
@@ -35,6 +35,7 @@ import org.activiti.runtime.api.model.builders.TaskPayloadBuilder;
 import org.activiti.runtime.api.model.impl.TaskImpl;
 import org.activiti.runtime.api.model.payloads.CreateTaskPayload;
 import org.activiti.runtime.api.query.Page;
+import org.activiti.runtime.api.query.impl.PageImpl;
 import org.activiti.runtime.conf.CommonModelAutoConfiguration;
 import org.activiti.runtime.conf.TaskModelAutoConfiguration;
 import org.junit.Before;
@@ -125,7 +126,7 @@ public class TaskControllerImplIT {
     public void getTasks() throws Exception {
 
         List<Task> taskList = Collections.singletonList(buildDefaultAssignedTask());
-        org.activiti.runtime.api.query.Page<Task> tasks = new org.activiti.runtime.api.query.impl.PageImpl<>(taskList,
+        Page<Task> tasks = new PageImpl<>(taskList,
                                                                                                              taskList.size());
         when(securityAwareTaskService.getAuthorizedTasks(any())).thenReturn(tasks);
 
@@ -140,7 +141,7 @@ public class TaskControllerImplIT {
     @Test
     public void getTasksShouldUseAlfrescoGuidelineWhenMediaTypeIsApplicationJson() throws Exception {
         List<Task> taskList = Collections.singletonList(buildDefaultAssignedTask());
-        org.activiti.runtime.api.query.Page<Task> taskPage = new org.activiti.runtime.api.query.impl.PageImpl<>(taskList,
+        Page<Task> taskPage = new PageImpl<>(taskList,
                                                                                                                 taskList.size());
         when(securityAwareTaskService.getAuthorizedTasks(any())).thenReturn(taskPage);
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
@@ -74,7 +74,7 @@ public class TaskVariableControllerImplIT {
     @Autowired
     private MockMvc mockMvc;
 
-    @SpyBean
+    @Autowired
     private ObjectMapper mapper;
 
     @MockBean


### PR DESCRIPTION
It's not possible to use @SpyBean around ObjectMapper anymore. In this specify case we don't really need to spy the instance so let's autowire it.