### PR TITLE
Improve TaskAdminController in runtime-bundle-service #2066

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskAdminController.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/TaskAdminController.java
@@ -1,16 +1,48 @@
 package org.activiti.cloud.services.rest.api;
 
+import org.activiti.api.task.model.payloads.ClaimTaskPayload;
+import org.activiti.api.task.model.payloads.CompleteTaskPayload;
+import org.activiti.api.task.model.payloads.DeleteTaskPayload;
+import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
+import org.activiti.api.task.model.payloads.SetTaskVariablesPayload;
 import org.activiti.cloud.services.rest.api.resources.TaskResource;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 @RequestMapping(value = "/admin/v1/tasks", produces = {MediaTypes.HAL_JSON_VALUE, MediaType.APPLICATION_JSON_VALUE})
 public interface TaskAdminController {
 
-    @RequestMapping( method = RequestMethod.GET)
+    @RequestMapping(method = RequestMethod.GET)
     PagedResources<TaskResource> getAllTasks(Pageable pageable);
+
+    @RequestMapping(value = "/{taskId}", method = RequestMethod.GET)
+    TaskResource getTaskById(@PathVariable String taskId);
+
+    @RequestMapping(value = "/{taskId}/claim", method = RequestMethod.POST)
+    TaskResource claimTask(@PathVariable String taskId,
+                           @RequestBody ClaimTaskPayload claimTaskPayload);
+
+    @RequestMapping(value = "/{taskId}/release", method = RequestMethod.POST)
+    TaskResource releaseTask(@PathVariable String taskId,
+                             @RequestBody ReleaseTaskPayload releaseTaskPayload);
+
+    @RequestMapping(value = "/{taskId}/complete", method = RequestMethod.POST)
+    TaskResource completeTask(@PathVariable String taskId,
+                              @RequestBody CompleteTaskPayload completeTaskPayload);
+
+    @RequestMapping(value = "/{taskId}", method = RequestMethod.DELETE)
+    TaskResource delete(@PathVariable String taskId,
+                        @RequestBody DeleteTaskPayload deleteTaskPayload);
+
+    @RequestMapping(value = "/{taskId}/variables", method = RequestMethod.POST)
+    ResponseEntity<Void> setVariables(@PathVariable String taskId,
+                                      @RequestBody SetTaskVariablesPayload setVariablesPayload);
+
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/asciidoc/index.adoc
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/asciidoc/index.adoc
@@ -272,3 +272,47 @@ include::{snippets}/task-variable/set/local/http-request.adoc[]
 .Response
 include::{snippets}/task-variable/set/local/http-response.adoc[]
 
+=== Task Admin
+
+==== List all tasks
+.Request
+include::{snippets}/task-admin/list/http-request.adoc[]
+
+.Response
+include::{snippets}/task-admin/task/http-response.adoc[]
+
+==== Get task by id
+.Request
+include::{snippets}/task-admin/task/http-request.adoc[]
+
+.Response
+include::{snippets}/task-admin/task/http-response.adoc[]
+
+==== Claim task
+.Request
+include::{snippets}/task-admin/task/claim/http-request.adoc[]
+
+.Response
+include::{snippets}/task-admin/task/claim/http-response.adoc[]
+
+==== Release task
+.Request
+include::{snippets}/task-admin/task/release/http-request.adoc[]
+
+.Response
+include::{snippets}/task-admin/task/release/http-response.adoc[]
+
+==== Complete task
+.Request
+include::{snippets}/task-admin/task/complete/http-request.adoc[]
+
+.Response
+include::{snippets}/task-admin/task/complete/http-response.adoc[]
+
+==== Delete task
+.Request
+include::{snippets}/task-admin/task/delete/http-request.adoc[]
+
+.Response
+include::{snippets}/task-admin/task/delete/http-response.adoc[]
+

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImpl.java
@@ -17,6 +17,11 @@ package org.activiti.cloud.services.rest.controllers;
 
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.task.model.Task;
+import org.activiti.api.task.model.payloads.ClaimTaskPayload;
+import org.activiti.api.task.model.payloads.CompleteTaskPayload;
+import org.activiti.api.task.model.payloads.DeleteTaskPayload;
+import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
+import org.activiti.api.task.model.payloads.SetTaskVariablesPayload;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
@@ -26,6 +31,10 @@ import org.activiti.cloud.services.rest.assemblers.TaskResourceAssembler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.PagedResources;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -57,5 +66,46 @@ public class TaskAdminControllerImpl implements TaskAdminController {
                                                   pageConverter.toSpringPage(pageable,
                                                                              tasksPage),
                                                   taskResourceAssembler);
+    }
+
+    @Override
+    public TaskResource getTaskById(@PathVariable String taskId) {
+        return taskResourceAssembler.toResource(taskAdminRuntime.task(taskId));
+    }
+
+    @Override
+    public TaskResource claimTask(@PathVariable String taskId,
+                                  @RequestBody ClaimTaskPayload claimTaskPayload) {
+        claimTaskPayload.setTaskId(taskId);
+        return taskResourceAssembler.toResource(taskAdminRuntime.claim(claimTaskPayload));
+    }
+
+    @Override
+    public TaskResource releaseTask(@PathVariable String taskId,
+                                    @RequestBody ReleaseTaskPayload releaseTaskPayload) {
+        releaseTaskPayload.setTaskId(taskId);
+        return taskResourceAssembler.toResource(taskAdminRuntime.release(releaseTaskPayload));
+    }
+
+    @Override
+    public TaskResource completeTask(@PathVariable String taskId,
+                                     @RequestBody CompleteTaskPayload completeTaskPayload) {
+        completeTaskPayload.setTaskId(taskId);
+        return taskResourceAssembler.toResource(taskAdminRuntime.complete(completeTaskPayload));
+    }
+
+    @Override
+    public TaskResource delete(@PathVariable String taskId,
+                               @RequestBody DeleteTaskPayload deleteTaskPayload) {
+        deleteTaskPayload.setTaskId(taskId);
+        return taskResourceAssembler.toResource(taskAdminRuntime.delete(deleteTaskPayload));
+    }
+
+    @Override
+    public ResponseEntity<Void> setVariables(@PathVariable String taskId,
+                                             @RequestBody SetTaskVariablesPayload setVariablesPayload) {
+        setVariablesPayload.setTaskId(taskId);
+        taskAdminRuntime.setVariables(setVariablesPayload);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
@@ -17,10 +17,14 @@
 package org.activiti.cloud.services.rest.controllers;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.task.model.Task;
+import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
@@ -46,12 +50,19 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.taskFields;
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.taskIdParameter;
 import static org.activiti.cloud.services.rest.controllers.TaskSamples.buildDefaultAssignedTask;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
+import static org.activiti.cloud.services.rest.controllers.TaskSamples.buildStandAloneTask;
+import static org.activiti.cloud.services.rest.controllers.TaskSamples.buildTask;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,9 +79,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TaskAdminControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "task-admin";
+    private static final String DOCUMENTATION_IDENTIFIER_ALFRESCO = "task-admin-alfresco";
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper mapper;
 
     @MockBean
     private TaskAdminRuntime taskAdminRuntime;
@@ -112,8 +127,252 @@ public class TaskAdminControllerImplIT {
 
         this.mockMvc.perform(get("/admin/v1/tasks?skipCount=10&maxItems=10").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andDo(document(DOCUMENTATION_IDENTIFIER + "/list",
+                .andDo(document(DOCUMENTATION_IDENTIFIER_ALFRESCO + "/list",
                                 pageRequestParameters(),
                                 pagedResourcesResponseFields()));
+    }
+
+    @Test
+    public void getTaskById() throws Exception {
+        when(taskAdminRuntime.task("task1")).thenReturn(buildStandAloneTask("task1",
+                                                                            "task1 description"));
+        this.mockMvc.perform(get("/admin/v1/tasks/{taskId}",
+                                 "task1"))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER + "/task",
+                                taskIdParameter(),
+                                links(
+                                        linkWithRel("claim").optional().description("The task's claim option."),
+                                        linkWithRel("self").optional().description("The task's resource."),
+                                        linkWithRel("home").optional().description("Home resource")
+                                )));
+    }
+
+    @Test
+    public void getTaskByIdShouldUseAlfrescoGuidelineWhenMediaTypeIsApplicationJson() throws Exception {
+        when(taskAdminRuntime.task("task1")).thenReturn(buildStandAloneTask("task1",
+                                                                            "task1 description"));
+        this.mockMvc.perform(get("/admin/v1/tasks/{taskId}",
+                                 "task1").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER_ALFRESCO + "/task",
+                                taskIdParameter(),
+                                taskFields()
+                ));
+    }
+
+    @Test
+    public void claimTask() throws Exception {
+        Task claimedTask = buildTask(Task.TaskStatus.ASSIGNED,
+                                     "task to be claimed",
+                                     "user");
+
+        when(taskAdminRuntime.claim(any())).thenReturn(claimedTask);
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/claim",
+                                  claimedTask.getId())
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .claim()
+                                                                                .withTaskId(claimedTask.getId())
+                                                                                .withAssignee(claimedTask.getAssignee())
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER + "/task/claim",
+                                taskIdParameter(),
+                                links(
+                                        linkWithRel("self").description("The task's resource."),
+                                        linkWithRel("release").description("The task's release option."),
+                                        linkWithRel("complete").description("The task's complete option."),
+                                        linkWithRel("processInstance").description("The task's option to get the process instance associated with."),
+                                        linkWithRel("home").description("Home resource")
+                                )));
+    }
+
+    @Test
+    public void claimTaskShouldUseAlfrescoGuidelineWhenMediaTypeIsApplicationJson() throws Exception {
+        Task claimedTask = buildTask(Task.TaskStatus.ASSIGNED,
+                                     "task to be claimed",
+                                     "user");
+
+        when(taskAdminRuntime.claim(any())).thenReturn(claimedTask);
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/claim",
+                                  claimedTask.getId())
+                                     .accept(MediaType.APPLICATION_JSON)
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .claim()
+                                                                                .withTaskId(claimedTask.getId())
+                                                                                .withAssignee(claimedTask.getAssignee())
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER_ALFRESCO + "/task/claim",
+                                taskIdParameter(),
+                                taskFields()));
+    }
+
+    @Test
+    public void releaseTask() throws Exception {
+        Task released = buildTask("task to be released",
+                                  Task.TaskStatus.CREATED);
+        when(taskAdminRuntime.release(any())).thenReturn(released);
+
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/release",
+                                  released.getId())
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .release()
+                                                                                .withTaskId(released.getId())
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER + "/task/release",
+                                taskIdParameter(),
+                                links(
+                                        linkWithRel("self").description("The task's resource."),
+                                        linkWithRel("claim").optional().description("The task's claim option."),
+                                        linkWithRel("processInstance").description("The task's option to get the process instance associated with."),
+                                        linkWithRel("home").description("Home resource")
+                                )));
+    }
+
+    @Test
+    public void releaseTaskShouldUseAlfrescoGuidelineWhenMediaTypeIsApplicationJson() throws Exception {
+        Task released = buildTask("task to be released",
+                                  Task.TaskStatus.CREATED);
+        when(taskAdminRuntime.release(any())).thenReturn(released);
+
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/release",
+                                  released.getId())
+                                     .accept(MediaType.APPLICATION_JSON)
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .release()
+                                                                                .withTaskId(released.getId())
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER_ALFRESCO + "/task/release",
+                                taskIdParameter(),
+                                taskFields()));
+    }
+
+    @Test
+    public void completeTask() throws Exception {
+        Task completed = buildTask("task to be completed",
+                                   Task.TaskStatus.COMPLETED);
+        when(taskAdminRuntime.complete(any())).thenReturn(completed);
+
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/complete",
+                                  completed.getId())
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .complete()
+                                                                                .withTaskId(completed.getId())
+                                                                                .withVariable("var-key",
+                                                                                              "var-value")
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER + "/task/complete",
+                                taskIdParameter(),
+                                links(
+                                        linkWithRel("self").description("The task's resource."),
+                                        linkWithRel("claim").optional().description("The task's claim option."),
+                                        linkWithRel("processInstance").description("The task's option to get the process instance associated with."),
+                                        linkWithRel("home").description("Home resource")
+                                )));
+    }
+
+    @Test
+    public void completeTaskShouldUseAlfrescoGuidelineWhenMediaTypeIsApplicationJson() throws Exception {
+        Task completed = buildTask("task to be completed",
+                                   Task.TaskStatus.COMPLETED);
+        when(taskAdminRuntime.complete(any())).thenReturn(completed);
+
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/complete",
+                                  completed.getId())
+                                     .accept(MediaType.APPLICATION_JSON)
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .complete()
+                                                                                .withTaskId(completed.getId())
+                                                                                .withVariable("var-key",
+                                                                                              "var-value")
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER_ALFRESCO + "/task/complete",
+                                taskIdParameter(),
+                                taskFields()));
+    }
+
+    @Test
+    public void deleteTask() throws Exception {
+        Task deleted = buildTask("task to be deleted",
+                                 Task.TaskStatus.DELETED);
+        when(taskAdminRuntime.delete(any())).thenReturn(deleted);
+
+        this.mockMvc.perform(delete("/admin/v1/tasks/{taskId}",
+                                    deleted.getId())
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .delete()
+                                                                                .withTaskId(deleted.getId())
+                                                                                .withReason("it has to be deleted")
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER + "/task/delete",
+                                taskIdParameter(),
+                                links(
+                                        linkWithRel("self").description("The task's resource."),
+                                        linkWithRel("claim").optional().description("The task's claim option."),
+                                        linkWithRel("processInstance").description("The task's option to get the process instance associated with."),
+                                        linkWithRel("home").description("Home resource")
+                                )));
+    }
+
+    @Test
+    public void deleteTaskShouldUseAlfrescoGuidelineWhenMediaTypeIsApplicationJson() throws Exception {
+        Task deleted = buildTask("task to be deleted",
+                                 Task.TaskStatus.DELETED);
+        when(taskAdminRuntime.delete(any())).thenReturn(deleted);
+
+        this.mockMvc.perform(delete("/admin/v1/tasks/{taskId}",
+                                    deleted.getId())
+                                     .accept(MediaType.APPLICATION_JSON)
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .delete()
+                                                                                .withTaskId(deleted.getId())
+                                                                                .withReason("it has to be deleted")
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk())
+                .andDo(document(DOCUMENTATION_IDENTIFIER_ALFRESCO + "/task/delete",
+                                taskIdParameter(),
+                                taskFields()));
+    }
+
+    @Test
+    public void setTaskVariables() throws Exception {
+        Task task = buildTask("task to be deleted",
+                              Task.TaskStatus.DELETED);
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("var- key1",
+                      "var-value1");
+        this.mockMvc.perform(post("/admin/v1/tasks/{taskId}/variables",
+                                  task.getId())
+                                     .contentType(MediaType.APPLICATION_JSON)
+                                     .content(mapper.writeValueAsString(TaskPayloadBuilder
+                                                                                .setVariables()
+                                                                                .withTaskId(task.getId())
+                                                                                .withVariables(variables)
+                                                                                .build()
+                                     )))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
- added more methods for TaskAdminController since they are available in activiti-api

refs [#2066](https://github.com/Activiti/Activiti/issues/2066)

**requires** this PR from common to be merged [#83](https://github.com/Activiti/activiti-cloud-service-common/pull/83) first