### PR TITLE
Send event directly for task update

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -87,9 +87,9 @@ public class CloudEventsAutoConfiguration {
 
     @Bean
     public CloudTaskUpdatedProducer cloudTaskUpdatedProducer(ToCloudTaskRuntimeEventConverter taskRuntimeEventConverter,
-                                                             ProcessEngineEventsAggregator eventsAggregator) {
+                                                             ProcessEngineChannels processEngineChannels) {
         return new CloudTaskUpdatedProducer(taskRuntimeEventConverter,
-                                            eventsAggregator);
+                                            processEngineChannels);
     }
 
     @Bean

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudTaskUpdatedProducer.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudTaskUpdatedProducer.java
@@ -18,21 +18,25 @@ package org.activiti.cloud.services.events.listeners;
 
 import org.activiti.api.task.runtime.events.TaskUpdatedEvent;
 import org.activiti.api.task.runtime.events.listener.TaskEventListener;
+import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.converter.ToCloudTaskRuntimeEventConverter;
+import org.springframework.messaging.support.MessageBuilder;
 
 public class CloudTaskUpdatedProducer implements TaskEventListener<TaskUpdatedEvent> {
 
     private ToCloudTaskRuntimeEventConverter converter;
-    private ProcessEngineEventsAggregator eventsAggregator;
+    private ProcessEngineChannels producer;
 
     public CloudTaskUpdatedProducer(ToCloudTaskRuntimeEventConverter converter,
-                                    ProcessEngineEventsAggregator eventsAggregator) {
+                                    ProcessEngineChannels producer) {
         this.converter = converter;
-        this.eventsAggregator = eventsAggregator;
+        this.producer = producer;
     }
 
     @Override
     public void onEvent(TaskUpdatedEvent event) {
-        eventsAggregator.add(converter.from(event));
+        producer.auditProducer().send(MessageBuilder.withPayload(
+                converter.from(event)).build());
     }
+
 }

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -55,7 +55,6 @@ import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TAS
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_COMPLETED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_CREATED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_SUSPENDED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_UPDATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -161,8 +160,7 @@ public class AuditProducerIT {
         taskRestTemplate.claim(task);
         await().untilAsserted(() -> assertThat(streamHandler.getReceivedEvents())
                 .extracting(event -> event.getEventType().name())
-                .containsExactly(TASK_ASSIGNED.name(),
-                                 TASK_UPDATED.name()
+                .containsExactly(TASK_ASSIGNED.name()
                 ));
 
         //when


### PR DESCRIPTION
As the event is coming from an api call there is no need to aggregate as there will be a single event

Refs https://github.com/Activiti/Activiti/issues/2129