### PR TITLE
fix: Rename REST endpoint to resume a suspended process

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
@@ -36,11 +36,11 @@ public interface ProcessInstanceController {
     @RequestMapping(value = "/signal")
     ResponseEntity<Void> sendSignal(@RequestBody SignalPayload signalPayload);
 
-    @RequestMapping(value = "{processInstanceId}/suspend")
+    @RequestMapping(value = "{processInstanceId}/suspend", method = RequestMethod.POST)
     ProcessInstanceResource suspend(@PathVariable String processInstanceId);
 
-    @RequestMapping(value = "{processInstanceId}/activate")
-    ProcessInstanceResource activate(@RequestBody String processInstanceId);
+    @RequestMapping(value = "{processInstanceId}/resume", method = RequestMethod.POST)
+    ProcessInstanceResource resume(@RequestBody String processInstanceId);
 
     @RequestMapping(value = "/{processInstanceId}", method = RequestMethod.DELETE)
     ProcessInstanceResource deleteProcessInstance(@PathVariable String processInstanceId);

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -142,7 +142,7 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
     }
 
     @Override
-    public ProcessInstanceResource activate(@PathVariable String processInstanceId) {
+    public ProcessInstanceResource resume(@PathVariable String processInstanceId) {
         return resourceAssembler.toResource(processRuntime.resume(ProcessPayloadBuilder.resume(processInstanceId)));
     }
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
@@ -16,6 +16,25 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
+import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -56,25 +75,6 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
-import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = ProcessInstanceControllerImpl.class, secure = false)
@@ -262,7 +262,7 @@ public class ProcessInstanceControllerImplIT {
         ProcessInstance processInstance = mock(ProcessInstance.class);
         when(processRuntime.processInstance("1")).thenReturn(processInstance);
         when(processRuntime.suspend(any())).thenReturn(defaultProcessInstance());
-        this.mockMvc.perform(get("/v1/process-instances/{processInstanceId}/suspend",
+        this.mockMvc.perform(post("/v1/process-instances/{processInstanceId}/suspend",
                                  1))
                 .andExpect(status().isOk())
                 .andDo(document(DOCUMENTATION_IDENTIFIER + "/suspend",
@@ -270,14 +270,14 @@ public class ProcessInstanceControllerImplIT {
     }
 
     @Test
-    public void activate() throws Exception {
+    public void resume() throws Exception {
         ProcessInstance processInstance = mock(ProcessInstance.class);
         when(processRuntime.processInstance("1")).thenReturn(processInstance);
         when(processRuntime.resume(any())).thenReturn(defaultProcessInstance());
-        this.mockMvc.perform(get("/v1/process-instances/{processInstanceId}/activate",
+        this.mockMvc.perform(post("/v1/process-instances/{processInstanceId}/resume",
                                  1))
                 .andExpect(status().isOk())
-                .andDo(document(DOCUMENTATION_IDENTIFIER + "/activate",
+                .andDo(document(DOCUMENTATION_IDENTIFIER + "/resume",
                                 pathParameters(parameterWithName("processInstanceId").description("The process instance id"))));
     }
 

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndPointITStreamHandler.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndPointITStreamHandler.java
@@ -32,7 +32,7 @@ public class CommandEndPointITStreamHandler {
 
     private AtomicBoolean startedProcessInstanceAck = new AtomicBoolean(false);
     private AtomicBoolean suspendedProcessInstanceAck = new AtomicBoolean(false);
-    private AtomicBoolean activatedProcessInstanceAck = new AtomicBoolean(false);
+    private AtomicBoolean resumedProcessInstanceAck = new AtomicBoolean(false);
     private AtomicBoolean claimedTaskAck = new AtomicBoolean(false);
     private AtomicBoolean releasedTaskAck = new AtomicBoolean(false);
     private AtomicBoolean completedTaskAck = new AtomicBoolean(false);
@@ -52,7 +52,7 @@ public class CommandEndPointITStreamHandler {
         } else if (result.getPayload() instanceof SuspendProcessPayload) {
             suspendedProcessInstanceAck.set(true);
         } else if (result.getPayload() instanceof ResumeProcessPayload) {
-            activatedProcessInstanceAck.set(true);
+            resumedProcessInstanceAck.set(true);
         } else if (result.getPayload() instanceof ClaimTaskPayload) {
             claimedTaskAck.set(true);
         } else if (result.getPayload() instanceof ReleaseTaskPayload) {
@@ -82,8 +82,8 @@ public class CommandEndPointITStreamHandler {
         return suspendedProcessInstanceAck;
     }
 
-    public AtomicBoolean getActivatedProcessInstanceAck() {
-        return activatedProcessInstanceAck;
+    public AtomicBoolean getResumedProcessInstanceAck() {
+        return resumedProcessInstanceAck;
     }
 
     public AtomicBoolean getClaimedTaskAck() {

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -18,6 +18,12 @@
 
 package org.activiti.cloud.starter.tests.cmdendpoint;
 
+import static org.activiti.api.task.model.Task.TaskStatus.ASSIGNED;
+import static org.activiti.api.task.model.Task.TaskStatus.CREATED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -63,12 +69,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.activiti.api.task.model.Task.TaskStatus.ASSIGNED;
-import static org.activiti.api.task.model.Task.TaskStatus.CREATED;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(CommandEndPointITStreamHandler.COMMAND_ENDPOINT_IT)
@@ -185,7 +185,7 @@ public class CommandEndpointIT {
 
         assertThat(streamHandler.getStartedProcessInstanceAck()).isTrue();
         assertThat(streamHandler.getSuspendedProcessInstanceAck()).isTrue();
-        assertThat(streamHandler.getActivatedProcessInstanceAck()).isTrue();
+        assertThat(streamHandler.getResumedProcessInstanceAck()).isTrue();
         assertThat(streamHandler.getClaimedTaskAck()).isTrue();
         assertThat(streamHandler.getReleasedTaskAck()).isTrue();
         assertThat(streamHandler.getCompletedTaskAck()).isTrue();
@@ -290,7 +290,7 @@ public class CommandEndpointIT {
         clientStream.myCmdProducer().send(MessageBuilder.withPayload(resumeProcess).setHeader("cmdId",
                                                                                               resumeProcess.getId()).build());
 
-        await("process to be activated").untilTrue(streamHandler.getActivatedProcessInstanceAck());
+        await("process to be resumed").untilTrue(streamHandler.getResumedProcessInstanceAck());
 
         await().untilAsserted(() -> {
 

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -16,6 +16,8 @@
 
 package org.activiti.cloud.starter.tests.helper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.Map;
 
@@ -36,8 +38,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Component
 public class ProcessInstanceRestTemplate {
@@ -170,7 +170,7 @@ public class ProcessInstanceRestTemplate {
     }
 
     public ResponseEntity<Void> resume(ResponseEntity<CloudProcessInstance> startProcessEntity) {
-        ResponseEntity<Void> responseEntity = testRestTemplate.exchange(PROCESS_INSTANCES_RELATIVE_URL + startProcessEntity.getBody().getId() + "/activate",
+        ResponseEntity<Void> responseEntity = testRestTemplate.exchange(PROCESS_INSTANCES_RELATIVE_URL + startProcessEntity.getBody().getId() + "/resume",
                                                                         HttpMethod.POST,
                                                                         null,
                                                                         new ParameterizedTypeReference<Void>() {

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -343,7 +343,7 @@ public class ProcessInstanceIT {
     }
 
     @Test
-    public void activateShouldPutASuspendedProcessInstanceBackToActiveState() {
+    public void resumeShouldPutASuspendedProcessInstanceBackToActiveState() {
         //given
         ResponseEntity<CloudProcessInstance> startProcessEntity = processInstanceRestTemplate.startProcess(processDefinitionIds.get(SIMPLE_PROCESS));
         executeRequestSuspendProcess(startProcessEntity);


### PR DESCRIPTION
Fixes Activiti/Activiti#2126

The existing controller used HTTP GET method to accept requests for /suspend and /resume endpoints. This PR changes HTTP method to use POST according to RESTful API best practices.