### PR TITLE
Trigger process deployed events

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfigurationIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfigurationIT.java
@@ -16,16 +16,18 @@
 
 package org.activiti.services.connectors.conf;
 
+import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.core.common.spring.security.policies.ProcessSecurityPoliciesManager;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
-import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.activiti.services.connectors.behavior.MQServiceTaskBehavior;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +40,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 
 @RunWith(SpringRunner.class)
@@ -61,6 +65,14 @@ public class CloudConnectorsAutoConfigurationIT {
 
     @MockBean
     private TaskService taskService;
+
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
+    @Before
+    public void setUp() {
+        doNothing().when(processDeployedProducer).onApplicationEvent(any());
+    }
 
     @Test
     public void shouldProvideMQServiceTaskBehaviorBean() {

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/configuration/CloudEventsAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.activiti.cloud.services.events.listeners.CloudActivityStartedProducer
 import org.activiti.cloud.services.events.listeners.CloudProcessCancelledProducer;
 import org.activiti.cloud.services.events.listeners.CloudProcessCompletedProducer;
 import org.activiti.cloud.services.events.listeners.CloudProcessCreatedProducer;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.events.listeners.CloudProcessResumedProducer;
 import org.activiti.cloud.services.events.listeners.CloudProcessStartedProducer;
 import org.activiti.cloud.services.events.listeners.CloudProcessSuspendedProducer;
@@ -47,6 +48,8 @@ import org.activiti.cloud.services.events.listeners.CloudVariableDeletedProducer
 import org.activiti.cloud.services.events.listeners.CloudVariableUpdatedProducer;
 import org.activiti.cloud.services.events.listeners.MessageProducerCommandContextCloseListener;
 import org.activiti.cloud.services.events.listeners.ProcessEngineEventsAggregator;
+import org.activiti.engine.RepositoryService;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -248,6 +251,15 @@ public class CloudEventsAutoConfiguration {
     public CloudSequenceFlowTakenProducer cloudSequenceFlowTakenProducer(ToCloudProcessRuntimeEventConverter converter,
                                                                          ProcessEngineEventsAggregator eventsAggregator) {
         return new CloudSequenceFlowTakenProducer(converter, eventsAggregator);
+    }
+
+    @Bean
+    public CloudProcessDeployedProducer cloudProcessDeployedProducer(RepositoryService repositoryService,
+                                                                     APIProcessDefinitionConverter converter,
+                                                                     RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+                                                                     ProcessEngineChannels processEngineChannels) {
+        return new CloudProcessDeployedProducer(repositoryService, converter, runtimeBundleInfoAppender,
+                                                processEngineChannels);
     }
 
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/converter/RuntimeBundleInfoAppender.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/converter/RuntimeBundleInfoAppender.java
@@ -28,13 +28,13 @@ public class RuntimeBundleInfoAppender {
         this.properties = properties;
     }
 
-    public void appendRuntimeBundleInfoTo(CloudRuntimeEventImpl<?,?> cloudProcessStartedEvent) {
-        cloudProcessStartedEvent.setAppName(properties.getAppName());
-        cloudProcessStartedEvent.setAppVersion(properties.getAppVersion());
-        cloudProcessStartedEvent.setServiceName(properties.getServiceName());
-        cloudProcessStartedEvent.setServiceFullName(properties.getServiceFullName());
-        cloudProcessStartedEvent.setServiceType(properties.getServiceType());
-        cloudProcessStartedEvent.setServiceVersion(properties.getServiceVersion());
+    public void appendRuntimeBundleInfoTo(CloudRuntimeEventImpl<?,?> cloudRuntimeEvent) {
+        cloudRuntimeEvent.setAppName(properties.getAppName());
+        cloudRuntimeEvent.setAppVersion(properties.getAppVersion());
+        cloudRuntimeEvent.setServiceName(properties.getServiceName());
+        cloudRuntimeEvent.setServiceFullName(properties.getServiceFullName());
+        cloudRuntimeEvent.setServiceType(properties.getServiceType());
+        cloudRuntimeEvent.setServiceVersion(properties.getServiceVersion());
     }
 
     public void appendRuntimeBundleInfoTo(CloudRuntimeEntityImpl cloudRuntimeEntity) {

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/converter/ToCloudProcessRuntimeEventConverter.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/converter/ToCloudProcessRuntimeEventConverter.java
@@ -19,6 +19,7 @@ package org.activiti.cloud.services.events.converter;
 import org.activiti.api.process.model.events.BPMNActivityCancelledEvent;
 import org.activiti.api.process.model.events.BPMNActivityCompletedEvent;
 import org.activiti.api.process.model.events.BPMNActivityStartedEvent;
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
 import org.activiti.api.process.model.events.SequenceFlowTakenEvent;
 import org.activiti.api.process.runtime.events.ProcessCancelledEvent;
 import org.activiti.api.process.runtime.events.ProcessCompletedEvent;
@@ -32,6 +33,7 @@ import org.activiti.cloud.api.process.model.events.CloudBPMNActivityStartedEvent
 import org.activiti.cloud.api.process.model.events.CloudProcessCancelledEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessCompletedEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessCreatedEvent;
+import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessResumedEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessStartedEvent;
 import org.activiti.cloud.api.process.model.events.CloudProcessSuspendedEvent;
@@ -42,6 +44,7 @@ import org.activiti.cloud.api.process.model.impl.events.CloudBPMNActivityStarted
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCancelledEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCompletedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessCreatedEventImpl;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessResumedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessStartedEventImpl;
 import org.activiti.cloud.api.process.model.impl.events.CloudProcessSuspendedEventImpl;
@@ -120,6 +123,12 @@ public class ToCloudProcessRuntimeEventConverter {
 
     public CloudSequenceFlowTakenEvent from(SequenceFlowTakenEvent event) {
         CloudSequenceFlowTakenImpl cloudEvent = new CloudSequenceFlowTakenImpl(event.getEntity());
+        runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(cloudEvent);
+        return cloudEvent;
+    }
+
+    public CloudProcessDeployedEvent from(ProcessDeployedEvent event) {
+        CloudProcessDeployedEventImpl cloudEvent = new CloudProcessDeployedEventImpl(event.getEntity());
         runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(cloudEvent);
         return cloudEvent;
     }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducer.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.events.listeners;
+
+import java.util.List;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.activiti.cloud.api.process.model.impl.events.CloudProcessDeployedEventImpl;
+import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.activiti.engine.RepositoryService;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.support.MessageBuilder;
+
+public class CloudProcessDeployedProducer implements ApplicationListener<ApplicationReadyEvent> {
+
+    private RepositoryService repositoryService;
+    private APIProcessDefinitionConverter processDefinitionConverter;
+    private RuntimeBundleInfoAppender runtimeBundleInfoAppender;
+    private ProcessEngineChannels producer;
+
+    public CloudProcessDeployedProducer(RepositoryService repositoryService,
+                                        APIProcessDefinitionConverter processDefinitionConverter,
+                                        RuntimeBundleInfoAppender runtimeBundleInfoAppender,
+                                        ProcessEngineChannels producer) {
+        this.repositoryService = repositoryService;
+        this.processDefinitionConverter = processDefinitionConverter;
+        this.runtimeBundleInfoAppender = runtimeBundleInfoAppender;
+        this.producer = producer;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (!WebApplicationType.NONE.equals(event.getSpringApplication().getWebApplicationType())) {
+            List<ProcessDefinition> processDefinitions = processDefinitionConverter.from(repositoryService.createProcessDefinitionQuery().list());
+            producer.auditProducer().send(
+                    MessageBuilder
+                            .withPayload(
+                                    processDefinitions
+                                            .stream()
+                                            .map(definition -> {
+                                                CloudProcessDeployedEventImpl deployedEvent = new CloudProcessDeployedEventImpl(definition);
+                                                runtimeBundleInfoAppender.appendRuntimeBundleInfoTo(deployedEvent);
+                                                return deployedEvent;
+                                            })
+                                            .toArray(CloudRuntimeEvent<?, ?>[]::new))
+                            .build());
+        }
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/CloudProcessDeployedProducerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.events.listeners;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.activiti.cloud.api.model.shared.impl.events.CloudRuntimeEventImpl;
+import org.activiti.cloud.api.process.model.events.CloudProcessDeployedEvent;
+import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.repository.ProcessDefinitionQuery;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class CloudProcessDeployedProducerTest {
+
+    @InjectMocks
+    private CloudProcessDeployedProducer processDeployedProducer;
+
+    @Mock
+    private RepositoryService repositoryService;
+
+    @Mock
+    private APIProcessDefinitionConverter processDefinitionConverter;
+
+    @Mock
+    private RuntimeBundleInfoAppender runtimeBundleInfoAppender;
+
+    @Mock
+    private ProcessEngineChannels producer;
+
+    @Mock
+    private MessageChannel auditProducer;
+
+    @Captor
+    private ArgumentCaptor<Message<CloudProcessDeployedEvent[]>> messageCaptor;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(producer.auditProducer()).thenReturn(auditProducer);
+    }
+
+    @Test
+    public void shouldSendMessageWithDeployedProcessesWhenWebApplicationTypeIsServlet() {
+        //given
+        ProcessDefinitionQuery definitionQuery = mock(ProcessDefinitionQuery.class);
+        given(repositoryService.createProcessDefinitionQuery()).willReturn(definitionQuery);
+
+        List<ProcessDefinition> internalProcessDefinitions = Arrays.asList(mock(ProcessDefinition.class),
+                                                                           mock(ProcessDefinition.class));
+
+        given(definitionQuery.list()).willReturn(internalProcessDefinitions);
+
+        List<org.activiti.api.process.model.ProcessDefinition> apiProcessDefinitions = Arrays.asList(mock(org.activiti.api.process.model.ProcessDefinition.class),
+                                                                                                     mock(org.activiti.api.process.model.ProcessDefinition.class));
+        given(processDefinitionConverter.from(internalProcessDefinitions)).willReturn(apiProcessDefinitions);
+
+        //when
+        processDeployedProducer.onApplicationEvent(buildApplicationReadyEvent(WebApplicationType.SERVLET));
+
+        //then
+        verify(runtimeBundleInfoAppender, times(2)).appendRuntimeBundleInfoTo(any(CloudRuntimeEventImpl.class));
+        verify(auditProducer).send(messageCaptor.capture());
+        Message<CloudProcessDeployedEvent[]> message = messageCaptor.getValue();
+        assertThat(message.getPayload())
+                .extracting(CloudProcessDeployedEvent::getEntity)
+                .containsExactlyElementsOf(apiProcessDefinitions);
+    }
+
+    private ApplicationReadyEvent buildApplicationReadyEvent(WebApplicationType applicationType) {
+        ApplicationReadyEvent applicationReadyEvent = mock(ApplicationReadyEvent.class);
+        SpringApplication springApplication = mock(SpringApplication.class);
+        given(springApplication.getWebApplicationType()).willReturn(applicationType);
+        given(applicationReadyEvent.getSpringApplication()).willReturn(springApplication);
+        return applicationReadyEvent;
+    }
+
+    @Test
+    public void shouldNotSentMessageWhenWebApplicationTypeIsNone() {
+        //when
+        processDeployedProducer.onApplicationEvent(buildApplicationReadyEvent(WebApplicationType.NONE));
+
+        //then
+        verifyZeroInteractions(auditProducer);
+    }
+
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -28,6 +28,7 @@ import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.junit.Before;
@@ -89,9 +90,13 @@ public class ProcessDefinitionAdminControllerImplIT {
     @MockBean
     private ProcessEngineChannels processEngineChannels;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
@@ -33,6 +33,7 @@ import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.RepositoryService;
@@ -110,9 +111,13 @@ public class ProcessDefinitionControllerImplIT {
     @MockBean
     private ProcessRuntime processRuntime;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -16,21 +16,6 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
-import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -41,6 +26,7 @@ import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.junit.Before;
@@ -67,7 +53,7 @@ import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestP
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
 import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -104,9 +90,13 @@ public class ProcessInstanceAdminControllerImplIT {
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImplIT.java
@@ -16,25 +16,6 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
-import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -57,6 +38,7 @@ import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.image.exception.ActivitiInterchangeInfoNotFoundException;
@@ -75,6 +57,25 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
+import static org.activiti.cloud.services.rest.controllers.ProcessInstanceSamples.defaultProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = ProcessInstanceControllerImpl.class, secure = false)
@@ -113,9 +114,13 @@ public class ProcessInstanceControllerImplIT {
     @MockBean
     private ProcessRuntime processRuntime;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
@@ -26,6 +26,7 @@ import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.junit.Before;
@@ -87,10 +88,14 @@ public class ProcessInstanceTasksControllerImplIT {
     @MockBean
     private ProcessEngineChannels processEngineChannels;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(pageConverter).isNotNull();
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
@@ -17,7 +17,6 @@
 package org.activiti.cloud.services.rest.controllers;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -31,8 +30,8 @@ import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,6 +93,9 @@ public class ProcessInstanceVariableControllerImplIT {
     @MockBean
     private ProcessEngineChannels processEngineChannels;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         //this assertion is not really necessary. It's only here to remove warning
@@ -102,6 +104,7 @@ public class ProcessInstanceVariableControllerImplIT {
         //in the controller
         assertThat(resourcesAssembler).isNotNull();
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
@@ -26,6 +26,7 @@ import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.junit.Before;
@@ -81,10 +82,14 @@ public class TaskAdminControllerImplIT {
     @MockBean
     private ProcessEngineChannels processEngineChannels;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(pageConverter).isNotNull();
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
@@ -32,12 +32,11 @@ import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.model.impl.TaskImpl;
 import org.activiti.api.task.model.payloads.CreateTaskPayload;
 import org.activiti.api.task.runtime.TaskRuntime;
-import org.activiti.cloud.api.model.shared.impl.conf.CloudCommonModelAutoConfiguration;
-import org.activiti.cloud.api.task.model.impl.conf.CloudTaskModelAutoConfiguration;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.junit.Before;
@@ -119,10 +118,14 @@ public class TaskControllerImplIT {
     @Mock
     private Page<Task> taskPage;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     @Before
     public void setUp() {
         assertThat(springPageConverter).isNotNull();
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
@@ -29,9 +29,9 @@ import org.activiti.api.task.runtime.TaskRuntime;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.assemblers.TaskVariableInstanceResourceAssembler;
 import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,6 +90,9 @@ public class TaskVariableControllerImplIT {
     @MockBean
     private ProcessEngineChannels processEngineChannels;
 
+    @MockBean
+    private CloudProcessDeployedProducer processDeployedProducer;
+
     private static final String TASK_ID = UUID.randomUUID().toString();
     private static final String PROCESS_INSTANCE_ID = UUID.randomUUID().toString();
 
@@ -102,6 +105,7 @@ public class TaskVariableControllerImplIT {
         assertThat(resourcesAssembler).isNotNull();
         assertThat(variableInstanceResourceAssembler).isNotNull();
         assertThat(processEngineChannels).isNotNull();
+        assertThat(processDeployedProducer).isNotNull();
     }
 
     @Test

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -16,6 +16,7 @@
 
 package org.activiti.cloud.starter.tests.services.audit;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -33,14 +34,20 @@ import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.AU
 @EnableBinding(AuditConsumer.class)
 public class AuditConsumerStreamHandler {
 
-    private List<CloudRuntimeEvent<?,?>> receivedEvents = Collections.emptyList();
+    private List<CloudRuntimeEvent<?,?>> latestReceivedEvents = Collections.emptyList();
+    private List<CloudRuntimeEvent<?,?>> allReceivedEvents = new ArrayList<>();
 
     @StreamListener(AuditConsumer.AUDIT_CONSUMER)
     public void receive(CloudRuntimeEvent<?,?> ... events) {
-        receivedEvents = Arrays.asList(events);
+        latestReceivedEvents = Arrays.asList(events);
+        allReceivedEvents.addAll(latestReceivedEvents);
     }
 
-    public List<CloudRuntimeEvent<?, ?>> getReceivedEvents() {
-        return this.receivedEvents;
+    public List<CloudRuntimeEvent<?, ?>> getLatestReceivedEvents() {
+        return this.latestReceivedEvents;
+    }
+
+    public List<CloudRuntimeEvent<?, ?>> getAllReceivedEvents() {
+        return allReceivedEvents;
     }
 }


### PR DESCRIPTION
The events will be sent when the Spring Boot application is ready (ApplicationReadyEvent). A message grouping ProcessDeployedEvents will be triggered every time the application starts. Listeners to these events should be able do deal with duplicates.

Refs https://github.com/Activiti/Activiti/issues/2149