### PR TITLE
Add event type routing key prefix for engine and integration context

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/message/IntegrationContextRoutingKeyResolver.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/message/IntegrationContextRoutingKeyResolver.java
@@ -23,6 +23,8 @@ import org.activiti.cloud.services.events.message.RuntimeBundleInfoMessageHeader
 
 public class IntegrationContextRoutingKeyResolver extends AbstractMessageHeadersRoutingKeyResolver {
     
+    private static final String INTEGRATION_CONTEXT = "integrationContext";
+    
     public final String[] HEADER_KEYS = {RuntimeBundleInfoMessageHeaders.SERVICE_NAME,
                                          RuntimeBundleInfoMessageHeaders.APP_NAME,
                                          IntegrationContextMessageHeaders.CONNECTOR_TYPE,
@@ -31,5 +33,10 @@ public class IntegrationContextRoutingKeyResolver extends AbstractMessageHeaders
     @Override
     public String resolve(Map<String, Object> headers) {
         return build(headers, HEADER_KEYS);
+    }
+    
+    @Override
+    public String getPrefix() {
+        return INTEGRATION_CONTEXT;
     }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/message/IntegrationContextRoutingKeyResolverTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/message/IntegrationContextRoutingKeyResolverTest.java
@@ -39,7 +39,7 @@ public class IntegrationContextRoutingKeyResolverTest {
         String routingKey = subject.resolve(headers);
         
         // then
-        assertThat(routingKey).isEqualTo("service-name.app-name.connector-type.process-instance-id.business-key");
+        assertThat(routingKey).isEqualTo("integrationContext.service-name.app-name.connector-type.process-instance-id.business-key");
                 
     }
     

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/AbstractMessageHeadersRoutingKeyResolver.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/AbstractMessageHeadersRoutingKeyResolver.java
@@ -31,7 +31,7 @@ public abstract class AbstractMessageHeadersRoutingKeyResolver implements Routin
     public abstract String resolve(Map<String, Object> headers);
 
     protected String build(Map<String, Object> headers, String... keys) {
-        return Stream.of(keys)
+        return getPrefix() + DELIMITER + Stream.of(keys)
                      .map(headers::get)
                      .map(Optional::ofNullable)
                      .map(this::mapNullOrEmptyValue)
@@ -48,5 +48,7 @@ public abstract class AbstractMessageHeadersRoutingKeyResolver implements Routin
     protected String escapeIllegalCharacters(String value) {
         return value.replaceAll(ILLEGAL_CHARACTERS, REPLACEMENT);
     }
+    
+    public abstract String getPrefix(); 
 
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/AuditProducerRoutingKeyResolver.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/AuditProducerRoutingKeyResolver.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 public class AuditProducerRoutingKeyResolver extends AbstractMessageHeadersRoutingKeyResolver {
     
+    public final String ROUTING_KEY_PREFIX = "engineEvents";
     public final String[] HEADER_KEYS = {RuntimeBundleInfoMessageHeaders.SERVICE_NAME,
                                      RuntimeBundleInfoMessageHeaders.APP_NAME,
                                      ExecutionContextMessageHeaders.PROCESS_DEFINITION_KEY,
@@ -30,6 +31,11 @@ public class AuditProducerRoutingKeyResolver extends AbstractMessageHeadersRouti
     @Override
     public String resolve(Map<String, Object> headers) {
         return build(headers, HEADER_KEYS);
+    }
+
+    @Override
+    public String getPrefix() {
+        return ROUTING_KEY_PREFIX;
     }
     
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/MessageBuilderAppenderChain.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/message/MessageBuilderAppenderChain.java
@@ -86,9 +86,16 @@ public class MessageBuilderAppenderChain {
     // Default implementation 
     static class DefaultRoutingKeyResolver extends AbstractMessageHeadersRoutingKeyResolver {
 
+        private static final String EVENT_MESSAGE = "eventMessage";
+
         @Override
         public String resolve(Map<String, Object> headers) {
             return build(headers, MESSAGE_PAYLOAD_TYPE);
+        }
+
+        @Override
+        public String getPrefix() {
+            return EVENT_MESSAGE;
         }
         
     }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListenerTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListenerTest.java
@@ -51,7 +51,7 @@ import org.springframework.messaging.MessageChannel;
 
 public class MessageProducerCommandContextCloseListenerTest {
 
-    private static final String MOCK_ROUTING_KEY = "springAppName.appName.mockProcessDefinitionKey.mockProcessInstanceId.mockBusinessKey";
+    private static final String MOCK_ROUTING_KEY = "engineEvents.springAppName.appName.mockProcessDefinitionKey.mockProcessInstanceId.mockBusinessKey";
     private static final String MOCK_PARENT_PROCESS_NAME = "mockParentProcessName";
     private static final String LORG_ACTIVITI_CLOUD_API_MODEL_SHARED_EVENTS_CLOUD_RUNTIME_EVENT = "[Lorg.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;";
     private static final String MOCK_PROCESS_NAME = "mockProcessName";

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/message/AuditProducerRoutingKeyResolverTest.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/message/AuditProducerRoutingKeyResolverTest.java
@@ -39,7 +39,7 @@ public class AuditProducerRoutingKeyResolverTest {
         String routingKey = subject.resolve(headers);
         
         // then
-        assertThat(routingKey).isEqualTo("service-name.app-name.process-definition-key.process-instance-id.business-key");
+        assertThat(routingKey).isEqualTo("engineEvents.service-name.app-name.process-definition-key.process-instance-id.business-key");
                 
     }
 
@@ -56,7 +56,7 @@ public class AuditProducerRoutingKeyResolverTest {
         String routingKey = subject.resolve(headers);
         
         // then
-        assertThat(routingKey).isEqualTo("service-name.app-name.process-definition-key.process-instance-id._");
+        assertThat(routingKey).isEqualTo("engineEvents.service-name.app-name.process-definition-key.process-instance-id._");
                 
     }
 
@@ -73,7 +73,7 @@ public class AuditProducerRoutingKeyResolverTest {
         String routingKey = subject.resolve(headers);
         
         // then
-        assertThat(routingKey).isEqualTo("service-name.app-name.process-definition-key.process-instance-id._");
+        assertThat(routingKey).isEqualTo("engineEvents.service-name.app-name.process-definition-key.process-instance-id._");
                 
     }
 
@@ -90,7 +90,7 @@ public class AuditProducerRoutingKeyResolverTest {
         String routingKey = subject.resolve(headers);
         
         // then
-        assertThat(routingKey).isEqualTo("service-name.app-name.process-definition-key.process-instance-id.business-key");
+        assertThat(routingKey).isEqualTo("engineEvents.service-name.app-name.process-definition-key.process-instance-id.business-key");
                 
     }
     
@@ -103,7 +103,7 @@ public class AuditProducerRoutingKeyResolverTest {
         String routingKey = subject.resolve(headers);
         
         // then
-        assertThat(routingKey).isEqualTo("_._._._._");
+        assertThat(routingKey).isEqualTo("engineEvents._._._._._");
                 
     }
     


### PR DESCRIPTION
This PR adds event type prefix for routing key builders , so that it is possible to route and consume messages based event type filter, i.e. engineEvents.#, integrationContext.serviceName.# 

![image](https://user-images.githubusercontent.com/20428629/50814784-af4b7900-12cf-11e9-9e63-82679a0ad863.png)
