### PR TITLE
Add @Conditional RabbitCloudConnectorsAutoConfiguration for SCS Rabbit Binder

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/CloudConnectorsAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/CloudConnectorsAutoConfiguration.java
@@ -26,43 +26,21 @@ import org.activiti.runtime.api.connector.VariablesMatchHelper;
 import org.activiti.services.connectors.behavior.MQServiceTaskBehavior;
 import org.activiti.services.connectors.message.IntegrationContextMessageBuilderFactory;
 import org.conf.activiti.runtime.api.ConnectorsAutoConfiguration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerProperties;
-import org.springframework.cloud.stream.binding.BinderAwareChannelResolver.NewDestinationBindingCallback;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.expression.Expression;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 @Configuration
 @AutoConfigureBefore(value = ConnectorsAutoConfiguration.class)
-@PropertySource("classpath:config/integration-result-stream.properties")
 @ComponentScan("org.activiti.core.common.spring.connector")
+@PropertySource("classpath:config/integration-result-stream.properties")
 public class CloudConnectorsAutoConfiguration {
 
-    @Value("${activiti.spring.cloud.stream.connector.integrationRequestSender.routing-key-expression}")
-    private String routingKeyExpression;
-
-    /**
-     * Configures routing key expression for dynamic cloud connector destinations if rabbit binder exists
-     */
-    @Bean
-    @ConditionalOnClass(RabbitProducerProperties.class)
-    @ConditionalOnMissingBean
-    public NewDestinationBindingCallback<RabbitProducerProperties> dynamicConnectorDestinationsBindingCallback() {
-        return (channelName, channel, producerProperties, extendedProducerProperties) -> {
-            Expression expression = new SpelExpressionParser().parseExpression(routingKeyExpression);
-            
-            extendedProducerProperties.setRoutingKeyExpression(expression);
-        };
-    }
     
     @Bean
     @ConditionalOnMissingBean

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/RabbitCloudConnectorsAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/RabbitCloudConnectorsAutoConfiguration.java
@@ -1,0 +1,34 @@
+package org.conf.activiti.services.connectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.binder.rabbit.properties.RabbitProducerProperties;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver.NewDestinationBindingCallback;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+/**
+ * Configures routing key expression for dynamic cloud connector destinations if rabbit binder exists on classpath
+ */
+@Configuration
+@ConditionalOnClass(RabbitProducerProperties.class)
+@AutoConfigureAfter(CloudConnectorsAutoConfiguration.class)
+public class RabbitCloudConnectorsAutoConfiguration {
+
+    @Value("${activiti.spring.cloud.stream.connector.integrationRequestSender.routing-key-expression:headers['routingKey']}")
+    private String routingKeyExpression;
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public NewDestinationBindingCallback<RabbitProducerProperties> dynamicConnectorDestinationsBindingCallback() {
+        return (channelName, channel, producerProperties, extendedProducerProperties) -> {
+            Expression expression = new SpelExpressionParser().parseExpression(routingKeyExpression);
+            
+            extendedProducerProperties.setRoutingKeyExpression(expression);
+        };
+    }
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.conf.activiti.services.connectors.CloudConnectorsAutoConfiguration
+    org.conf.activiti.services.connectors.CloudConnectorsAutoConfiguration,\
+	org.conf.activiti.services.connectors.RabbitCloudConnectorsAutoConfiguration

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/pom.xml
@@ -100,10 +100,6 @@
       <artifactId>spring-cloud-stream</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/pom.xml
@@ -58,10 +58,6 @@
       <artifactId>spring-cloud-stream</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
     </dependency>

--- a/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -70,6 +70,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+    </dependency>    
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>
     </dependency>

--- a/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
-      <optional>true</optional>
     </dependency>    
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -72,6 +72,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-stream-rabbit</artifactId>
+      <optional>true</optional>
     </dependency>    
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This PR fixes Activiti/Activiti#2394 by making `spring-cloud-starter-stream-rabbit ` dependency optional in connectors with @Conditional RabbitCloudConnectorsAutoConfiguration that enables configuration of routing key expression for dynamic cloud connector destinations if rabbit binder exists on classpath.

The approach is to make `spring-cloud-starter-stream-rabbit`optional in connectors module only. There is dedicated auto-configuration that configures `DynamicConnectorDestinationBindingCallback` when `RabbitProducerProperties.class` is `@Conditonal` on classpath on bootstrap.

The provided starter builds and ships with `the spring-cloud-starter-stream-rabbit` right now. If someone, wants to use `spring-cloud-starter-stream-kafka`, they can exclude 'spring-cloud-starter-stream-rabbit' from starter and add another binder implementation inside their build. 

For ultimate flexibility the starter could also make `spring-cloud-starter-stream-rabbit` optional, but it will be required to be included it in each example micro-service build...