### PR TITLE
 Move CloudActivityBehaviorFactory to runtime bundle

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscriptions/behavior/BroadcastSignalEventActivityBehavior.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscriptions/behavior/BroadcastSignalEventActivityBehavior.java
@@ -8,16 +8,20 @@ import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
-import org.activiti.spring.bpmn.parser.CloudActivityBehaviorFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-@Scope("prototype")
-@Component(CloudActivityBehaviorFactory.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME)
+import static org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME;
+
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@Component(DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME)
 public class BroadcastSignalEventActivityBehavior extends IntermediateThrowSignalEventActivityBehavior {
-    
+
+    public static final String DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME = "defaultThrowSignalEventBehavior";
+
     private static final long serialVersionUID = 1L;
 
     private final ApplicationEventPublisher eventPublisher;
@@ -45,9 +49,9 @@ public class BroadcastSignalEventActivityBehavior extends IntermediateThrowSigna
 
         SignalPayload signalPayload = new SignalPayload(eventSubscriptionName, execution.getVariables());
         eventPublisher.publishEvent(signalPayload);
-        
+
         Context.getAgenda().planTakeOutgoingSequenceFlowsOperation((ExecutionEntity) execution,
                 true);
-        
+
     }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+    org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration,\
+    org.activiti.core.common.spring.connector.autoconfigure.ConnectorAutoConfiguration

--- a/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -14,7 +14,6 @@
     <dependency>
       <groupId>org.activiti</groupId>
       <artifactId>activiti-engine</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.activiti.cloud.rb</groupId>

--- a/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/behavior/CloudActivityBehaviorFactory.java
+++ b/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/behavior/CloudActivityBehaviorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starter.rb.behavior;
+
+import org.activiti.bpmn.model.Signal;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.bpmn.model.ThrowEvent;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.parser.factory.DefaultActivityBehaviorFactory;
+import org.springframework.context.ApplicationContext;
+
+import static org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME;
+
+public class CloudActivityBehaviorFactory extends DefaultActivityBehaviorFactory {
+
+    private ApplicationContext applicationContext;
+
+    public CloudActivityBehaviorFactory(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent,
+                                                                                                           SignalEventDefinition signalEventDefinition,
+                                                                                                           Signal signal) {
+        return (IntermediateThrowSignalEventActivityBehavior) applicationContext.getBean(DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME, applicationContext, signalEventDefinition, signal);
+    }
+}

--- a/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiCloudEngineAutoConfiguration.java
+++ b/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiCloudEngineAutoConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starter.rb.configuration;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ActivitiCloudEngineAutoConfiguration {
+
+    @Bean
+    public SignalBehaviourConfigurer signalBehaviourConfigurator(ApplicationContext applicationContext){
+        return new SignalBehaviourConfigurer(applicationContext);
+    }
+
+}

--- a/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/SignalBehaviourConfigurer.java
+++ b/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/SignalBehaviourConfigurer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starter.rb.configuration;
+
+import org.activiti.cloud.starter.rb.behavior.CloudActivityBehaviorFactory;
+import org.activiti.spring.SpringProcessEngineConfiguration;
+import org.activiti.spring.boot.ProcessEngineConfigurationConfigurer;
+import org.springframework.context.ApplicationContext;
+
+public class SignalBehaviourConfigurer implements ProcessEngineConfigurationConfigurer {
+
+    private ApplicationContext applicationContext;
+
+    public SignalBehaviourConfigurer(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void configure(SpringProcessEngineConfiguration processEngineConfiguration) {
+        processEngineConfiguration.setActivityBehaviorFactory(new CloudActivityBehaviorFactory(applicationContext));
+    }
+}

--- a/activiti-cloud-starter-runtime-bundle/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-starter-runtime-bundle/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundleAutoConfiguration
+    org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundleAutoConfiguration,\
+  org.activiti.cloud.starter.rb.configuration.ActivitiCloudEngineAutoConfiguration

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.starter.tests.conf;
+
+import org.activiti.spring.SpringProcessEngineConfiguration;
+import org.activiti.cloud.starter.rb.behavior.CloudActivityBehaviorFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class EngineConfigurationIT {
+
+    @Autowired
+    private SpringProcessEngineConfiguration configuration;
+
+    @Test
+    public void shouldUseCloudCloudActivityBehaviorFactory() {
+        assertThat(configuration.getActivityBehaviorFactory()).isInstanceOf(CloudActivityBehaviorFactory.class);
+        assertThat(configuration.getBpmnParser().getActivityBehaviorFactory()).isInstanceOf(CloudActivityBehaviorFactory.class);
+    }
+}

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessDefinitionRestTemplate.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessDefinitionRestTemplate.java
@@ -16,29 +16,30 @@
 
 package org.activiti.cloud.starter.tests.helper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.activiti.cloud.api.process.model.CloudProcessDefinition;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 
-@Component
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestComponent
 public class ProcessDefinitionRestTemplate {
 
     private static final String PROCESS_DEFINITIONS_URL = "/v1/process-definitions/";
     private static final ParameterizedTypeReference<PagedResources<CloudProcessDefinition>> PAGED_DEFINITIONS_RESPONSE_TYPE = new ParameterizedTypeReference<PagedResources<CloudProcessDefinition>>() {
     };
 
-    @Autowired
     private TestRestTemplate testRestTemplate;
 
- 
+    public ProcessDefinitionRestTemplate(TestRestTemplate testRestTemplate) {
+        this.testRestTemplate = testRestTemplate;
+    }
+
     public ResponseEntity<PagedResources<CloudProcessDefinition>> getProcessDefinitions() {
         ResponseEntity<PagedResources<CloudProcessDefinition>> responseEntity = testRestTemplate.exchange(PROCESS_DEFINITIONS_URL,
                                          HttpMethod.GET,

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/ProcessInstanceRestTemplate.java
@@ -16,8 +16,6 @@
 
 package org.activiti.cloud.starter.tests.helper;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +30,7 @@ import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
 import org.activiti.engine.impl.util.IoUtil;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedResources;
@@ -43,19 +41,23 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RequestCallback;
 import org.springframework.web.client.ResponseExtractor;
 
-@Component
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestComponent
 public class ProcessInstanceRestTemplate {
 
     public static final String PROCESS_INSTANCES_RELATIVE_URL = "/v1/process-instances/";
 
-    public static final String PROCESS_INSTANCES_ADMIN_RELATIVE_URL = "/admin/v1/process-instances/";
+    private static final String PROCESS_INSTANCES_ADMIN_RELATIVE_URL = "/admin/v1/process-instances/";
 
-    @Autowired
     private TestRestTemplate testRestTemplate;
+
+    public ProcessInstanceRestTemplate(TestRestTemplate testRestTemplate) {
+        this.testRestTemplate = testRestTemplate;
+    }
 
     private ResponseEntity<CloudProcessInstance> startProcess(String processDefinitionKey,
                                                               String processDefinitionId,

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/TaskRestTemplate.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/TaskRestTemplate.java
@@ -30,7 +30,7 @@ import org.activiti.api.task.model.payloads.UpdateTaskPayload;
 import org.activiti.api.task.model.payloads.UpdateTaskVariablePayload;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
 import org.activiti.cloud.api.task.model.CloudTask;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedResources;
@@ -39,11 +39,10 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Component
+@TestComponent
 public class TaskRestTemplate {
 
     private static final String TASK_VAR_RELATIVE_URL = "/v1/tasks/";
@@ -58,8 +57,11 @@ public class TaskRestTemplate {
     private static final ParameterizedTypeReference<Void> VOID_RESPONSE_TYPE = new ParameterizedTypeReference<Void>() {
     };
 
-    @Autowired
     private TestRestTemplate testRestTemplate;
+
+    public TaskRestTemplate(TestRestTemplate testRestTemplate) {
+        this.testRestTemplate = testRestTemplate;
+    }
 
     public ResponseEntity<CloudTask> complete(Task task) {
         return complete(task,

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <url>http://activiti.org</url>
 
   <properties>
-    <activiti-dependencies.version>7.1.10</activiti-dependencies.version>
+    <activiti-dependencies.version>7.1.11</activiti-dependencies.version>
     <activiti-cloud-build.version>7.1.6</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>7.1.23</activiti-cloud-service-common.version>
     <activiti-cloud-runtime-bundle-service.version>${project.version}</activiti-cloud-runtime-bundle-service.version>


### PR DESCRIPTION
Initially CloudActivityBehaviorFactory was declared in set in Activiti core, but this was breaking intermediate throw signals when non-cloud starter was used.

Ref: https://github.com/Activiti/Activiti/issues/2663