### PR TITLE
fix: NPE in RabbitCloudConnectorsAutoConfiguration

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/RabbitCloudConnectorsAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/conf/activiti/services/connectors/RabbitCloudConnectorsAutoConfiguration.java
@@ -28,7 +28,9 @@ public class RabbitCloudConnectorsAutoConfiguration {
         return (channelName, channel, producerProperties, extendedProducerProperties) -> {
             Expression expression = new SpelExpressionParser().parseExpression(routingKeyExpression);
             
-            extendedProducerProperties.setRoutingKeyExpression(expression);
+            if(extendedProducerProperties != null) {
+                extendedProducerProperties.setRoutingKeyExpression(expression);
+            }
         };
     }
 }


### PR DESCRIPTION
This PR fixes https://github.com/Activiti/Activiti/issues/2718 in RabbitCloudConnectorsAutoConfiguration in case of running unit tests with Spring Cloud Stream Test Binder support

