### PR TITLE
[ACTIVITI-3585] Set required groups for auditProducer

### DIFF
--- a/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
+++ b/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
@@ -3,3 +3,5 @@ spring.activiti.deploymentMode=never-fail
 
 spring.activiti.async-executor.default-async-job-acquire-wait-time-in-millis=5000
 spring.activiti.async-executor.default-timer-job-acquire-wait-time-in-millis=5000
+
+spring.cloud.stream.bindings.auditProducer.producer.required-groups=${ACT_QUERY_CONSUMER_GROUP:query},${ACT_AUDIT_CONSUMER_GROUP:audit}

--- a/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
+++ b/activiti-cloud-starter-runtime-bundle/src/main/resources/metadata.properties
@@ -4,4 +4,5 @@ spring.activiti.deploymentMode=never-fail
 spring.activiti.async-executor.default-async-job-acquire-wait-time-in-millis=5000
 spring.activiti.async-executor.default-timer-job-acquire-wait-time-in-millis=5000
 
+#ensures the consumer (query, audit) will receive the message even if it starts after the message has been sent
 spring.cloud.stream.bindings.auditProducer.producer.required-groups=${ACT_QUERY_CONSUMER_GROUP:query},${ACT_AUDIT_CONSUMER_GROUP:audit}

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/conf/EngineConfigurationIT.java
@@ -16,8 +16,6 @@
 
 package org.activiti.cloud.starter.tests.conf;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.activiti.cloud.starter.rb.behavior.CloudActivityBehaviorFactory;
 import org.activiti.runtime.api.impl.MappingAwareActivityBehaviorFactory;
 import org.activiti.spring.SpringProcessEngineConfiguration;
@@ -25,8 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -35,6 +36,9 @@ public class EngineConfigurationIT {
 
     @Autowired
     private SpringProcessEngineConfiguration configuration;
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     @Test
     public void shouldUseCloudActivityBehaviorFactory() {
@@ -45,5 +49,13 @@ public class EngineConfigurationIT {
         assertThat(configuration.getBpmnParser().getActivityBehaviorFactory())
                 .isInstanceOf(MappingAwareActivityBehaviorFactory.class)
                 .isInstanceOf(CloudActivityBehaviorFactory.class);
+    }
+
+    @Test
+    public void shouldHaveRequiredGroupsSetForAuditProducer() {
+        //when
+        String requiredGroups = applicationContext.getEnvironment().getProperty("spring.cloud.stream.bindings.auditProducer.producer.required-groups");
+        //then
+        assertThat(requiredGroups).isEqualTo("query,audit");
     }
 }


### PR DESCRIPTION
This will ensure that consumer will received the message even in the case it starts after the message was sent.