### PR TITLE
feat: Add support for BPMN Message Rest Api 

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceAdminController.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceAdminController.java
@@ -1,5 +1,7 @@
 package org.activiti.cloud.services.rest.api;
 
+import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
+import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -8,6 +10,7 @@ import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,5 +45,12 @@ public interface ProcessInstanceAdminController {
     @RequestMapping(value = "/{processInstanceId}/subprocesses", method = RequestMethod.GET)
     PagedResources<Resource<CloudProcessInstance>> subprocesses(@PathVariable("processInstanceId") String processInstanceId,
                                                          Pageable pageable);
+    
+    @RequestMapping(value = "/message", method = RequestMethod.POST) 
+    Resource<CloudProcessInstance> start(@RequestBody StartMessagePayload startMessagePayload);
+
+    @RequestMapping(value = "/message", method = RequestMethod.PUT) 
+    ResponseEntity<Void> receive(@RequestBody ReceiveMessagePayload receiveMessagePayload);
+    
     
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-api/src/main/java/org/activiti/cloud/services/rest/api/ProcessInstanceController.java
@@ -1,6 +1,8 @@
 package org.activiti.cloud.services.rest.api;
 
+import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
+import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -37,6 +39,12 @@ public interface ProcessInstanceController {
     @RequestMapping(value = "/signal", method = RequestMethod.POST) 
     ResponseEntity<Void> sendSignal(@RequestBody SignalPayload signalPayload);
 
+    @RequestMapping(value = "/message", method = RequestMethod.POST) 
+    Resource<CloudProcessInstance> start(@RequestBody StartMessagePayload startMessagePayload);
+
+    @RequestMapping(value = "/message", method = RequestMethod.PUT) 
+    ResponseEntity<Void> receive(@RequestBody ReceiveMessagePayload receiveMessagePayload);
+    
     @RequestMapping(value = "{processInstanceId}/suspend", method = RequestMethod.POST)
     Resource<CloudProcessInstance> suspend(@PathVariable String processInstanceId);
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
@@ -17,6 +17,8 @@ package org.activiti.cloud.services.rest.controllers;
 
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
+import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
@@ -29,6 +31,8 @@ import org.activiti.cloud.services.rest.assemblers.ProcessInstanceResourceAssemb
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -107,6 +111,20 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
         return pagedResourcesAssembler.toResource(pageable,
                                                   pageConverter.toSpringPage(pageable, processInstancePage),
                                                   resourceAssembler);
+    }
+
+    @Override
+    public Resource<CloudProcessInstance> start(@RequestBody StartMessagePayload startMessagePayload) {
+        ProcessInstance processInstance = processAdminRuntime.start(startMessagePayload);
+        
+        return resourceAssembler.toResource(processInstance);
+    }
+
+    @Override
+    public ResponseEntity<Void> receive(@RequestBody ReceiveMessagePayload receiveMessagePayload) {
+        processAdminRuntime.receive(receiveMessagePayload);
+        
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -15,9 +15,15 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
+import static java.util.Collections.emptyList;
+
+import java.nio.charset.StandardCharsets;
+
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
+import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.api.process.runtime.ProcessRuntime;
@@ -39,10 +45,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.nio.charset.StandardCharsets;
-
-import static java.util.Collections.emptyList;
 
 @RestController
 public class ProcessInstanceControllerImpl implements ProcessInstanceController {
@@ -147,6 +149,20 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
         return pagedResourcesAssembler.toResource(pageable,
                                                   pageConverter.toSpringPage(pageable, processInstancePage),
                                                   resourceAssembler);
+    }
+
+    @Override
+    public Resource<CloudProcessInstance> start(@RequestBody StartMessagePayload startMessagePayload) {
+        ProcessInstance processInstance = processRuntime.start(startMessagePayload);
+        
+        return resourceAssembler.toResource(processInstance);
+    }
+
+    @Override
+    public ResponseEntity<Void> receive(@RequestBody ReceiveMessagePayload receiveMessagePayload) {
+        processRuntime.receive(receiveMessagePayload);
+        
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 }


### PR DESCRIPTION
This PR adds support for BPMN message Rest Api via dedicated `/message` endpoint for `ProcessInstance` and `ProcessInstanceAdmin` controllers, i.e.

```java
/**
 * Deliver start message payload via POST /message
 */
@RequestMapping(value = "/message", method = RequestMethod.POST) 
Resource<CloudProcessInstance> start(@RequestBody StartMessagePayload startMessagePayload);

/**
 * Deliver receive message payload via PUT /message
 */
@RequestMapping(value = "/message", method = RequestMethod.PUT) 
ResponseEntity<Void> receive(@RequestBody ReceiveMessagePayload receiveMessagePayload);

```

Part of https://github.com/Activiti/Activiti/issues/2637