### PR TITLE
Remove validation of vars when starting a process

### DIFF
--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImpl.java
@@ -92,12 +92,6 @@ public class ProcessInstanceAdminControllerImpl implements ProcessInstanceAdminC
    
     @Override
     public Resource<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload startProcessPayload) {
-        Map<String, Object> variables = startProcessPayload.getVariables(); 
-        if (variables != null && !variables.isEmpty()) {
-            
-            processVariablesValidator.checkStartProcessPayloadVariables(startProcessPayload,
-                                                                        getProcessDefinitionKey(startProcessPayload));
-        }    
         return resourceAssembler.toResource(processAdminRuntime.start(startProcessPayload));
     }
     

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceControllerImpl.java
@@ -113,14 +113,6 @@ public class ProcessInstanceControllerImpl implements ProcessInstanceController 
 
     @Override
     public Resource<CloudProcessInstance> startProcess(@RequestBody StartProcessPayload startProcessPayload) {
-        
-        Map<String, Object> variables = startProcessPayload.getVariables(); 
-        if (variables != null && !variables.isEmpty()) {   
-            
-            processVariablesValidator.checkStartProcessPayloadVariables(startProcessPayload,
-                                                                        getProcessDefinitionKey(startProcessPayload));
-        }    
-        
         return resourceAssembler.toResource(processRuntime.start(startProcessPayload));
     }
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessVariablesPayloadValidator.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/controllers/ProcessVariablesPayloadValidator.java
@@ -111,14 +111,4 @@ public class ProcessVariablesPayloadValidator  {
                               processDefinitionKey,
                               true);          
     }
-    
-
-    
-    public void checkStartProcessPayloadVariables(StartProcessPayload startProcessPayload,
-                                                  String processDefinitionKey) {
-        
-       checkPayloadVariables(startProcessPayload.getVariables(),
-                             processDefinitionKey,
-                             false);
-    }
 }


### PR DESCRIPTION
Removal of variable check when starting a process.
The process variable check relies on the existence of a variable definition present in the extension file, thus preventing the possibility to create new variables on the fly when starting a process
That logic is removed by this PR.