### PR TITLE
fix(ACTIVITI-3875): replaced activitivi:isInterrupting with isInterrupting attribute

### DIFF
--- a/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/MessageAuditProducerIT.bpmn20.xml
+++ b/activiti-cloud-starter-runtime-bundle/src/test/resources/processes/MessageAuditProducerIT.bpmn20.xml
@@ -31,7 +31,7 @@
       <bpmn:messageEventDefinition messageRef="Message_126jyr2" activiti:correlationKey="${invoiceKey}" />
     </bpmn:endEvent>
     <bpmn:subProcess id="SubProcess_018nkd6" triggeredByEvent="true">
-      <bpmn:startEvent id="startMessageEventSubprocessEvent" activiti:isInterrupting="false">
+      <bpmn:startEvent id="startMessageEventSubprocessEvent" isInterrupting="false">
         <bpmn:outgoing>SequenceFlow_0cyjl7n</bpmn:outgoing>
         <bpmn:messageEventDefinition messageRef="Message_0e6pytx" activiti:correlationKey="${correlationKey}"/>
       </bpmn:startEvent>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <url>http://activiti.org</url>
 
   <properties>
-    <activiti-dependencies.version>7.1.72</activiti-dependencies.version>
+    <activiti-dependencies.version>7.1.73</activiti-dependencies.version>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>7.1.67</activiti-cloud-service-common.version>
     <activiti-cloud-runtime-bundle-service.version>${project.version}</activiti-cloud-runtime-bundle-service.version>


### PR DESCRIPTION
This PR replaces `activiti:isInterrupting` attribute with `isInterrupting` for `auditEventSubprocessMessage` in `AuditMessageProducerIT` based on the changes in upstream PR: https://github.com/Activiti/Activiti/pull/2925

This PR should pass once the upstream PR is released and propagated.

![image](https://user-images.githubusercontent.com/20428629/65652689-753e1680-dfc7-11e9-885d-9ba621daed1f.png)

Part of https://github.com/Activiti/Activiti/issues/2637
