### PR TITLE
refactor(build): removed `@ComponentScan` from configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ notifications:
 
 before_script:
   - echo MAVEN_OPTS=-Xmx1536m > ~/.mavenrc
+  - docker pull activiti/activiti-keycloak
 
 # Enable integration tests
 script:
@@ -33,4 +34,4 @@ after_failure:
 
 env:
   global:
-  - DOCKER_HOST=tcp://127.0.0.1:2375
+  - DOCKER_HOST=tcp://localhost:2375

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
-before_install:
-  - docker pull activiti/activiti-keycloak
-
 before_script:
   - echo MAVEN_OPTS=-Xmx1536m > ~/.mavenrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,11 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
 
+before_install:
+  - docker pull activiti/activiti-keycloak
+
 before_script:
   - echo MAVEN_OPTS=-Xmx1536m > ~/.mavenrc
-  - docker pull activiti/activiti-keycloak
 
 # Enable integration tests
 script:
@@ -32,6 +34,6 @@ after_failure:
   - cat **/target/surefire-reports/*.xml | grep -B 1 -A 30 "<error"
   - cat **/target/failsafe-reports/*.xml | grep -B 1 -A 30 "<error"
 
-env:
-  global:
-  - DOCKER_HOST=tcp://localhost:2375
+# env:
+#   global:
+#   - DOCKER_HOST=tcp://localhost:2375

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/IntegrationRequestSender.java
@@ -23,11 +23,9 @@ import org.activiti.services.connectors.message.IntegrationContextMessageBuilder
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-@Component
 public class IntegrationRequestSender {
     public static final String CONNECTOR_TYPE = "connectorType";
     

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationResultEventHandler.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/main/java/org/activiti/services/connectors/channel/ServiceTaskIntegrationResultEventHandler.java
@@ -16,7 +16,7 @@
 
 package org.activiti.services.connectors.channel;
 
-import java.util.List;
+import static org.activiti.runtime.api.impl.MappingExecutionContext.buildMappingExecutionContext;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.IntegrationResult;
@@ -27,21 +27,16 @@ import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.activiti.engine.integration.IntegrationContextService;
 import org.activiti.engine.runtime.Execution;
-import org.activiti.runtime.api.impl.MappingExecutionContext;
 import org.activiti.runtime.api.impl.VariablesMappingProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-import static org.activiti.runtime.api.impl.MappingExecutionContext.buildMappingExecutionContext;
+import java.util.List;
 
-@Component
-@EnableBinding(ProcessEngineIntegrationChannels.class)
 public class ServiceTaskIntegrationResultEventHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ServiceTaskIntegrationResultEventHandler.class);

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfigurationIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-connectors/src/test/java/org/activiti/services/connectors/conf/CloudConnectorsAutoConfigurationIT.java
@@ -30,6 +30,7 @@ import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
+import org.activiti.engine.integration.IntegrationContextService;
 import org.activiti.services.connectors.behavior.MQServiceTaskBehavior;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,6 +42,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -56,7 +58,13 @@ public class CloudConnectorsAutoConfigurationIT {
     private IntegrationContextManager integrationContextManager;
 
     @MockBean
+    private IntegrationContextService integrationContextService;
+    
+    @MockBean
     private RuntimeBundleProperties runtimeBundleProperties;
+    
+    @MockBean(name = "auditProducer")
+    private  MessageChannel auditProducer;
 
     @MockBean
     private ApplicationEventPublisher eventPublisher;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/pom.xml
@@ -93,6 +93,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.hateoas</groupId>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDiagramGeneratorWrapper.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/ProcessDiagramGeneratorWrapper.java
@@ -16,9 +16,8 @@
 
 package org.activiti.cloud.services.core;
 
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
+import static java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment;
+import static java.util.Collections.emptyList;
 
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.engine.ActivitiException;
@@ -27,18 +26,16 @@ import org.activiti.image.exception.ActivitiImageException;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import static java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment;
-import static java.util.Collections.emptyList;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Service logic for generating process diagrams
  */
-@Service
 public class ProcessDiagramGeneratorWrapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDiagramGeneratorWrapper.class);
@@ -60,7 +57,6 @@ public class ProcessDiagramGeneratorWrapper {
     @Value("${activiti.diagram.generate.default:false}")
     private boolean generateDefaultDiagram;
 
-    @Autowired
     public ProcessDiagramGeneratorWrapper(ProcessDiagramGenerator processDiagramGenerator) {
         this.processDiagramGenerator = processDiagramGenerator;
     }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/ClaimTaskCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/ClaimTaskCmdExecutor.java
@@ -4,18 +4,14 @@ import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.payloads.ClaimTaskPayload;
 import org.activiti.api.task.model.results.TaskResult;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ClaimTaskCmdExecutor implements CommandExecutor<ClaimTaskPayload> {
 
     private TaskAdminRuntime taskAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public ClaimTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime,
                                 MessageChannel commandResults) {
         this.taskAdminRuntime = taskAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CommandEndpoint.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CommandEndpoint.java
@@ -1,27 +1,23 @@
 package org.activiti.cloud.services.core.commands;
 
+import org.activiti.api.model.shared.Payload;
+import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.activiti.api.model.shared.Payload;
-import org.activiti.cloud.services.events.ProcessEngineChannels;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.context.SecurityContextImpl;
-import org.springframework.stereotype.Component;
-
-@Component
 public class CommandEndpoint<T extends Payload> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommandEndpoint.class);
     private Map<String, CommandExecutor<T>> commandExecutors;
 
-    @Autowired
     public CommandEndpoint(Set<CommandExecutor<T>> cmdExecutors) {
         this.commandExecutors = cmdExecutors.stream().collect(Collectors.toMap(CommandExecutor::getHandledType,
                                                                                Function.identity()));

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CommandEndpointAdminAuthentication.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CommandEndpointAdminAuthentication.java
@@ -9,6 +9,8 @@ import java.util.Collection;
 
 public class CommandEndpointAdminAuthentication implements Authentication {
 
+    private static final long serialVersionUID = 1L;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Arrays.asList(new SimpleGrantedAuthority("ROLE_ACTIVITI_ADMIN"));

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CompleteTaskCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CompleteTaskCmdExecutor.java
@@ -4,18 +4,14 @@ import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.payloads.CompleteTaskPayload;
 import org.activiti.api.task.model.results.TaskResult;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class CompleteTaskCmdExecutor implements CommandExecutor<CompleteTaskPayload> {
 
     private TaskAdminRuntime taskAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public CompleteTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime,
                                    MessageChannel commandResults) {
         this.taskAdminRuntime = taskAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CreateTaskVariableCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/CreateTaskVariableCmdExecutor.java
@@ -3,18 +3,14 @@ package org.activiti.cloud.services.core.commands;
 import org.activiti.api.model.shared.EmptyResult;
 import org.activiti.api.task.model.payloads.CreateTaskVariablePayload;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class CreateTaskVariableCmdExecutor implements CommandExecutor<CreateTaskVariablePayload> {
 
     private TaskAdminRuntime taskAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public CreateTaskVariableCmdExecutor(TaskAdminRuntime taskAdminRuntime,
                                        	 MessageChannel commandResults) {
         this.taskAdminRuntime = taskAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/ReleaseTaskCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/ReleaseTaskCmdExecutor.java
@@ -4,18 +4,14 @@ import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
 import org.activiti.api.task.model.results.TaskResult;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ReleaseTaskCmdExecutor implements CommandExecutor<ReleaseTaskPayload> {
 
     private TaskAdminRuntime taskAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public ReleaseTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime,
                                   MessageChannel commandResults) {
         this.taskAdminRuntime = taskAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/RemoveProcessVariablesCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/RemoveProcessVariablesCmdExecutor.java
@@ -3,18 +3,14 @@ package org.activiti.cloud.services.core.commands;
 import org.activiti.api.model.shared.EmptyResult;
 import org.activiti.api.process.model.payloads.RemoveProcessVariablesPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class RemoveProcessVariablesCmdExecutor implements CommandExecutor<RemoveProcessVariablesPayload> {
 
     private ProcessAdminRuntime processAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public RemoveProcessVariablesCmdExecutor(ProcessAdminRuntime processAdminRuntime,
                                              MessageChannel commandResults) {
         this.processAdminRuntime = processAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/ResumeProcessInstanceCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/ResumeProcessInstanceCmdExecutor.java
@@ -4,18 +4,14 @@ import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.payloads.ResumeProcessPayload;
 import org.activiti.api.process.model.results.ProcessInstanceResult;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ResumeProcessInstanceCmdExecutor implements CommandExecutor<ResumeProcessPayload> {
 
     private ProcessAdminRuntime processAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public ResumeProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime,
                                             MessageChannel commandResults) {
         this.processAdminRuntime = processAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SetProcessVariablesCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SetProcessVariablesCmdExecutor.java
@@ -3,18 +3,14 @@ package org.activiti.cloud.services.core.commands;
 import org.activiti.api.model.shared.EmptyResult;
 import org.activiti.api.process.model.payloads.SetProcessVariablesPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SetProcessVariablesCmdExecutor implements CommandExecutor<SetProcessVariablesPayload> {
 
     private ProcessAdminRuntime processAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public SetProcessVariablesCmdExecutor(ProcessAdminRuntime processAdminRuntime,
                                           MessageChannel commandResults) {
         this.processAdminRuntime = processAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SignalCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SignalCmdExecutor.java
@@ -3,18 +3,14 @@ package org.activiti.cloud.services.core.commands;
 import org.activiti.api.model.shared.EmptyResult;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SignalCmdExecutor implements CommandExecutor<SignalPayload> {
 
     private ProcessAdminRuntime processAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public SignalCmdExecutor(ProcessAdminRuntime processAdminRuntime,
                              MessageChannel commandResults) {
         this.processAdminRuntime = processAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/StartProcessInstanceCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/StartProcessInstanceCmdExecutor.java
@@ -6,9 +6,7 @@ import org.activiti.api.process.model.results.ProcessInstanceResult;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class StartProcessInstanceCmdExecutor implements CommandExecutor<StartProcessPayload> {
 
     private ProcessAdminRuntime processAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SuspendProcessInstanceCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/SuspendProcessInstanceCmdExecutor.java
@@ -4,18 +4,14 @@ import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.payloads.SuspendProcessPayload;
 import org.activiti.api.process.model.results.ProcessInstanceResult;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SuspendProcessInstanceCmdExecutor implements CommandExecutor<SuspendProcessPayload> {
 
     private ProcessAdminRuntime processAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public SuspendProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime,
                                              MessageChannel commandResults) {
         this.processAdminRuntime = processAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/UpdateTaskVariableCmdExecutor.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/commands/UpdateTaskVariableCmdExecutor.java
@@ -1,21 +1,16 @@
 package org.activiti.cloud.services.core.commands;
 
 import org.activiti.api.model.shared.EmptyResult;
-import org.activiti.api.task.model.payloads.CreateTaskVariablePayload;
 import org.activiti.api.task.model.payloads.UpdateTaskVariablePayload;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class UpdateTaskVariableCmdExecutor implements CommandExecutor<UpdateTaskVariablePayload> {
 
     private TaskAdminRuntime taskAdminRuntime;
     private MessageChannel commandResults;
 
-    @Autowired
     public UpdateTaskVariableCmdExecutor(TaskAdminRuntime taskAdminRuntime,
                                        	 MessageChannel commandResults) {
         this.taskAdminRuntime = taskAdminRuntime;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/conf/ServicesCoreAutoConfiguration.java
@@ -16,9 +16,35 @@
 
 package org.activiti.cloud.services.core.conf;
 
+import org.activiti.api.model.shared.Payload;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
+import org.activiti.cloud.services.core.commands.ClaimTaskCmdExecutor;
+import org.activiti.cloud.services.core.commands.CommandEndpoint;
+import org.activiti.cloud.services.core.commands.CommandExecutor;
+import org.activiti.cloud.services.core.commands.CompleteTaskCmdExecutor;
+import org.activiti.cloud.services.core.commands.CreateTaskVariableCmdExecutor;
+import org.activiti.cloud.services.core.commands.ReleaseTaskCmdExecutor;
+import org.activiti.cloud.services.core.commands.RemoveProcessVariablesCmdExecutor;
+import org.activiti.cloud.services.core.commands.ResumeProcessInstanceCmdExecutor;
+import org.activiti.cloud.services.core.commands.SetProcessVariablesCmdExecutor;
+import org.activiti.cloud.services.core.commands.SignalCmdExecutor;
+import org.activiti.cloud.services.core.commands.StartProcessInstanceCmdExecutor;
+import org.activiti.cloud.services.core.commands.SuspendProcessInstanceCmdExecutor;
+import org.activiti.cloud.services.core.commands.UpdateTaskVariableCmdExecutor;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
+import org.activiti.cloud.services.core.pageable.sort.ProcessDefinitionSortApplier;
+import org.activiti.cloud.services.core.pageable.sort.ProcessInstanceSortApplier;
+import org.activiti.cloud.services.core.pageable.sort.TaskSortApplier;
+import org.activiti.image.ProcessDiagramGenerator;
+import org.activiti.image.impl.DefaultProcessDiagramGenerator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.MessageChannel;
+
+import java.util.Set;
 
 @Configuration
 public class ServicesCoreAutoConfiguration {
@@ -27,4 +53,130 @@ public class ServicesCoreAutoConfiguration {
     public SpringPageConverter pageConverter(){
         return new SpringPageConverter();
     }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public ClaimTaskCmdExecutor claimTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime,
+                                                     MessageChannel commandResults) {
+        return new ClaimTaskCmdExecutor(taskAdminRuntime, 
+                                        commandResults);
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public CompleteTaskCmdExecutor completeTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime,
+                                                           MessageChannel commandResults) {
+        return new CompleteTaskCmdExecutor(taskAdminRuntime,
+                                           commandResults);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public CreateTaskVariableCmdExecutor createTaskVariableCmdExecutor(TaskAdminRuntime taskAdminRuntime,
+                                                                       MessageChannel commandResults) {
+        return new CreateTaskVariableCmdExecutor(taskAdminRuntime,
+                                                 commandResults);
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public ReleaseTaskCmdExecutor releaseTaskCmdExecutor(TaskAdminRuntime taskAdminRuntime,
+                                                         MessageChannel commandResults) {
+        return new ReleaseTaskCmdExecutor(taskAdminRuntime,
+                                          commandResults);
+    }    
+
+    @Bean
+    @ConditionalOnMissingBean
+    public UpdateTaskVariableCmdExecutor updateTaskVariableCmdExecutor(TaskAdminRuntime taskAdminRuntime,
+                                                                       MessageChannel commandResults) {
+        return new UpdateTaskVariableCmdExecutor(taskAdminRuntime,
+                                                 commandResults);
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public RemoveProcessVariablesCmdExecutor removeProcessVariablesCmdExecutor(ProcessAdminRuntime processAdminRuntime,
+                                                                               MessageChannel commandResults) {
+        return new RemoveProcessVariablesCmdExecutor(processAdminRuntime,
+                                                     commandResults);
+    }    
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ResumeProcessInstanceCmdExecutor resumeProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime,
+                                                                             MessageChannel commandResults) {
+        return new ResumeProcessInstanceCmdExecutor(processAdminRuntime,
+                                                    commandResults);
+    }  
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public SetProcessVariablesCmdExecutor setProcessVariablesCmdExecutor(ProcessAdminRuntime processAdminRuntime,
+                                                                         MessageChannel commandResults) {
+        return new SetProcessVariablesCmdExecutor(processAdminRuntime,
+                                                  commandResults);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SignalCmdExecutor signalCmdExecutor(ProcessAdminRuntime processAdminRuntime,
+                                               MessageChannel commandResults) {
+        return new SignalCmdExecutor(processAdminRuntime,
+                                     commandResults);
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public StartProcessInstanceCmdExecutor startProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime,
+                                                                           MessageChannel commandResults) {
+        return new StartProcessInstanceCmdExecutor(processAdminRuntime,
+                                                   commandResults);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SuspendProcessInstanceCmdExecutor suspendProcessInstanceCmdExecutor(ProcessAdminRuntime processAdminRuntime,
+                                                                               MessageChannel commandResults) {
+        return new SuspendProcessInstanceCmdExecutor(processAdminRuntime,
+                                                     commandResults);
+    }    
+    
+    @Bean
+    public <T extends Payload> CommandEndpoint<T> commandEndpoint(Set<CommandExecutor<T>> cmdExecutors) {
+        return new CommandEndpoint<>(cmdExecutors);
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionSortApplier processDefinitionSortApplier() {
+        return new ProcessDefinitionSortApplier();
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessInstanceSortApplier processInstanceSortApplier() {
+        return new ProcessInstanceSortApplier();
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public TaskSortApplier taskSortApplier() {
+        return new TaskSortApplier();
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDiagramGenerator processDiagramGenerator() {
+        return new DefaultProcessDiagramGenerator();
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDiagramGeneratorWrapper processDiagramGeneratorWrapper(ProcessDiagramGenerator processDiagramGenerator) {
+        return new ProcessDiagramGeneratorWrapper(processDiagramGenerator);
+        
+    }
+    
+
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/pageable/sort/ProcessDefinitionSortApplier.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/pageable/sort/ProcessDefinitionSortApplier.java
@@ -15,16 +15,14 @@
 
 package org.activiti.cloud.services.core.pageable.sort;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.activiti.engine.impl.ProcessDefinitionQueryProperty;
 import org.activiti.engine.query.QueryProperty;
 import org.activiti.engine.repository.ProcessDefinitionQuery;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Component;
 
-@Component
+import java.util.HashMap;
+import java.util.Map;
+
 public class ProcessDefinitionSortApplier extends BaseSortApplier<ProcessDefinitionQuery> {
 
     private Map<String, QueryProperty> orderByProperties = new HashMap<>();

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/pageable/sort/ProcessInstanceSortApplier.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/pageable/sort/ProcessInstanceSortApplier.java
@@ -15,16 +15,14 @@
 
 package org.activiti.cloud.services.core.pageable.sort;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.activiti.engine.impl.ProcessInstanceQueryProperty;
 import org.activiti.engine.query.QueryProperty;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Component;
 
-@Component
+import java.util.HashMap;
+import java.util.Map;
+
 public class ProcessInstanceSortApplier extends BaseSortApplier<ProcessInstanceQuery> {
 
     private Map<String, QueryProperty> orderByProperties = new HashMap<>();

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/pageable/sort/TaskSortApplier.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/main/java/org/activiti/cloud/services/core/pageable/sort/TaskSortApplier.java
@@ -16,16 +16,14 @@
 
 package org.activiti.cloud.services.core.pageable.sort;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.activiti.engine.impl.TaskQueryProperty;
 import org.activiti.engine.query.QueryProperty;
 import org.activiti.engine.task.TaskQuery;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Component;
 
-@Component
+import java.util.HashMap;
+import java.util.Map;
+
 public class TaskSortApplier extends BaseSortApplier<TaskQuery> {
 
     private Map<String, TaskQueryProperty> orderByProperties = new HashMap<>();

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDiagramGeneratorWrapperIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDiagramGeneratorWrapperIT.java
@@ -16,9 +16,6 @@
 
 package org.activiti.cloud.services.core;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.cloud.services.core.utils.TestProcessEngine;
 import org.activiti.cloud.services.core.utils.TestProcessEngineConfiguration;
@@ -36,13 +33,15 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 /**
  * Integration tests for ProcessDiagramGeneratorWrapper
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = TestProcessEngineConfiguration.class)
 @TestPropertySource("classpath:test-process-diagram.properties")
-//@ContextConfiguration(classes=TestProcessEngineConfiguration.class)\
 public class ProcessDiagramGeneratorWrapperIT {
 
     private static final String DEFAULT_DIAGRAM_FONT_NAME = "Arial";

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDiagramGeneratorWrapperIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/ProcessDiagramGeneratorWrapperIT.java
@@ -16,6 +16,9 @@
 
 package org.activiti.cloud.services.core;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.cloud.services.core.utils.TestProcessEngine;
 import org.activiti.cloud.services.core.utils.TestProcessEngineConfiguration;
@@ -27,25 +30,27 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 /**
  * Integration tests for ProcessDiagramGeneratorWrapper
  */
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = TestProcessEngineConfiguration.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = TestProcessEngineConfiguration.class)
 @TestPropertySource("classpath:test-process-diagram.properties")
+//@ContextConfiguration(classes=TestProcessEngineConfiguration.class)\
 public class ProcessDiagramGeneratorWrapperIT {
 
     private static final String DEFAULT_DIAGRAM_FONT_NAME = "Arial";
+    
+    @SpringBootApplication
+    static class Application {
+        
+    }
 
     @SpyBean
     private ProcessDiagramGeneratorWrapper processDiagramGenerator;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/MockMessageChannel.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/MockMessageChannel.java
@@ -18,9 +18,7 @@ package org.activiti.cloud.services.core.utils;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.stereotype.Component;
 
-@Component
 public class MockMessageChannel implements MessageChannel {
 
     @Override

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/MockProcessEngineChannels.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/MockProcessEngineChannels.java
@@ -19,9 +19,7 @@ package org.activiti.cloud.services.core.utils;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.stereotype.Component;
 
-@Component
 public class MockProcessEngineChannels implements ProcessEngineChannels {
 
     @Override

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/TestProcessEngine.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/TestProcessEngine.java
@@ -16,25 +16,21 @@
 
 package org.activiti.cloud.services.core.utils;
 
-import java.io.IOException;
-
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.engine.ProcessEngine;
 import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.runtime.ProcessInstance;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+
+import java.io.IOException;
 
 /**
  * Wrapper over ProcessEngine for testing purposes.
  * It helps to unify the calls to process engine services from tests.
  */
-@Component
 public class TestProcessEngine {
 
     private final ProcessEngine processEngine;
 
-    @Autowired
     public TestProcessEngine(final ProcessEngine processEngine) {
         this.processEngine = processEngine;
     }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/TestProcessEngineConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-core/src/test/java/org/activiti/cloud/services/core/utils/TestProcessEngineConfiguration.java
@@ -28,11 +28,8 @@ import org.activiti.image.impl.DefaultProcessDiagramGenerator;
 import org.activiti.validation.ProcessValidator;
 import org.activiti.validation.ProcessValidatorImpl;
 import org.activiti.validation.validator.ValidatorSetFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
@@ -40,28 +37,24 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 /**
  * Test context configuration for integration tests over Activiti process engine
  */
-@Configuration
-@ComponentScan({
-        "org.activiti.engine",
-        "org.activiti.image",
-        "org.activiti.core.common.spring.security",
-        "org.activiti.core.common.spring.identity",
-        "org.activiti.core.common.spring.connector",
-        "org.activiti.cloud.services.events.listeners",
-        "org.activiti.cloud.services.events.converter",
-        "org.activiti.cloud.services.events.configuration",
-        "org.activiti.cloud.services.core",
-        "org.activiti.cloud.services.core.pageable",
-        "org.activiti.cloud.services.core.utils"
-
-
-})
-@EnableAutoConfiguration
+@TestConfiguration
 public class TestProcessEngineConfiguration {
 
-    @Autowired
-    private ProcessEngine processEngine;
-
+    @Bean
+    public TestProcessEngine testProcessEngine(ProcessEngine processEngine) {
+        return new TestProcessEngine(processEngine);
+    }
+    
+    @Bean
+    public MockMessageChannel mockMessageChannel() {
+        return new MockMessageChannel();
+    }
+    
+    @Bean
+    public MockProcessEngineChannels mockProcessEngineChannels() {
+        return new MockProcessEngineChannels();
+    }
+    
     @Bean
     public ProcessEngine processEngine() {
         return ProcessEngineConfiguration
@@ -71,22 +64,22 @@ public class TestProcessEngineConfiguration {
     }
 
     @Bean
-    public RuntimeService runtimeService() {
+    public RuntimeService runtimeService(ProcessEngine processEngine) {
         return processEngine.getRuntimeService();
     }
 
     @Bean
-    public ManagementService managementService() {
+    public ManagementService managementService(ProcessEngine processEngine) {
         return processEngine.getManagementService();
     }
     
     @Bean
-    public RepositoryService repositoryService() {
+    public RepositoryService repositoryService(ProcessEngine processEngine) {
         return processEngine.getRepositoryService();
     }
 
     @Bean
-    public TaskService taskService() {
+    public TaskService taskService(ProcessEngine processEngine) {
         return processEngine.getTaskService();
     }
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration
+  org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration,\
+  org.activiti.cloud.services.events.configuration.RuntimeBundleProperties

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/tests/util/MockProcessEngineChannels.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/test/java/org/activiti/cloud/services/events/tests/util/MockProcessEngineChannels.java
@@ -3,9 +3,7 @@ package org.activiti.cloud.services.events.tests.util;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.stereotype.Component;
 
-@Component
 public class MockProcessEngineChannels implements ProcessEngineChannels {
 
     @Override

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-basic/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-basic/pom.xml
@@ -39,10 +39,6 @@
       <artifactId>spring-security-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-keycloak/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-keycloak/pom.xml
@@ -35,10 +35,6 @@
       <artifactId>keycloak-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/config/RuntimeBundleSecurityAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/config/RuntimeBundleSecurityAutoConfiguration.java
@@ -18,68 +18,18 @@ package org.activiti.cloud.services.identity.keycloak.config;
 
 import org.activiti.cloud.services.common.security.keycloak.config.CommonSecurityAutoConfiguration;
 import org.activiti.cloud.services.identity.keycloak.KeycloakActivitiAuthenticationProvider;
-import org.keycloak.adapters.AdapterDeploymentContext;
-import org.keycloak.adapters.KeycloakConfigResolver;
-import org.keycloak.adapters.springsecurity.AdapterDeploymentContextFactoryBean;
-import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
-import org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticatedActionsFilter;
-import org.keycloak.adapters.springsecurity.filter.KeycloakAuthenticationProcessingFilter;
-import org.keycloak.adapters.springsecurity.filter.KeycloakPreAuthActionsFilter;
-import org.keycloak.adapters.springsecurity.filter.KeycloakSecurityContextRequestFilter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.Resource;
+import org.springframework.context.annotation.Configuration;
 
-@KeycloakConfiguration
-public class RuntimeBundleSecurityAutoConfiguration extends CommonSecurityAutoConfiguration {
+@Configuration
+@AutoConfigureBefore(CommonSecurityAutoConfiguration.class)
+public class RuntimeBundleSecurityAutoConfiguration {
 
-    @Value("${keycloak.configurationFile:WEB-INF/keycloak.json}")
-    private Resource keycloakConfigFileResource;
-
-    @Autowired(
-            required = false
-    )
-    private KeycloakConfigResolver keycloakConfigResolver;
-
-    protected KeycloakAuthenticationProvider keycloakAuthenticationProvider() {
+    @Bean
+    public KeycloakAuthenticationProvider keycloakAuthenticationProvider() {
         return new KeycloakActivitiAuthenticationProvider();
-    }
-
-    @Bean
-    protected KeycloakPreAuthActionsFilter keycloakPreAuthActionsFilter() {
-        return new KeycloakPreAuthActionsFilter(this.httpSessionManager());
-    }
-
-    @Bean
-    protected AdapterDeploymentContext adapterDeploymentContext() throws Exception {
-        AdapterDeploymentContextFactoryBean factoryBean;
-        if (this.keycloakConfigResolver != null) {
-            factoryBean = new AdapterDeploymentContextFactoryBean(this.keycloakConfigResolver);
-        } else {
-            factoryBean = new AdapterDeploymentContextFactoryBean(this.keycloakConfigFileResource);
-        }
-
-        factoryBean.afterPropertiesSet();
-        return factoryBean.getObject();
-    }
-
-    @Bean
-    protected KeycloakSecurityContextRequestFilter keycloakSecurityContextRequestFilter() {
-        return new KeycloakSecurityContextRequestFilter();
-    }
-
-    @Bean
-    protected KeycloakAuthenticatedActionsFilter keycloakAuthenticatedActionsRequestFilter() {
-        return new KeycloakAuthenticatedActionsFilter();
-    }
-
-    @Bean
-    protected KeycloakAuthenticationProcessingFilter keycloakAuthenticationProcessingFilter() throws Exception {
-        KeycloakAuthenticationProcessingFilter filter = new KeycloakAuthenticationProcessingFilter(this.authenticationManagerBean());
-        filter.setSessionAuthenticationStrategy(this.sessionAuthenticationStrategy());
-        return filter;
     }
 
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakTestApplication.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-identity-keycloak/src/test/java/org/activiti/cloud/services/identity/keycloak/KeycloakTestApplication.java
@@ -1,17 +1,17 @@
 package org.activiti.cloud.services.identity.keycloak;
 
 import org.activiti.cloud.services.common.security.keycloak.config.CommonSecurityAutoConfiguration;
+import org.activiti.cloud.services.test.TestConfiguration;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
-@SpringBootApplication(exclude = CommonSecurityAutoConfiguration.class)
+@SpringBootApplication(exclude = {CommonSecurityAutoConfiguration.class, TestConfiguration.class})
 @EnableWebSecurity
-public class Application {
+public class KeycloakTestApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class,
-                args);
+        SpringApplication.run(KeycloakTestApplication.class,
+                              args);
     }
 }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
@@ -25,7 +25,6 @@ import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.context.SmartLifecycle;
-import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
 
@@ -35,7 +34,7 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
     private static final String MESSAGE_BASED_JOB_MANAGER = "messageBasedJobManager";
     public static final String JOB_MESSAGE_HANDLER = "jobMessageHandler";
 
-    private String contentType = MediaType.APPLICATION_JSON_VALUE;
+    private String contentType = "application/json";
 
     private final BindingService bindingService;
     private final JobMessageInputChannelFactory inputChannelFactory;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-job-executor/src/main/java/org/activiti/cloud/services/job/executor/MessageBasedJobManagerConfigurator.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.stream.binder.ConsumerProperties;
 import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.http.MediaType;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
 
@@ -34,7 +35,7 @@ public class MessageBasedJobManagerConfigurator implements ProcessEngineConfigur
     private static final String MESSAGE_BASED_JOB_MANAGER = "messageBasedJobManager";
     public static final String JOB_MESSAGE_HANDLER = "jobMessageHandler";
 
-    private String contentType = "application/json";
+    private String contentType = MediaType.APPLICATION_JSON_VALUE;
 
     private final BindingService bindingService;
     private final JobMessageInputChannelFactory inputChannelFactory;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/pom.xml
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/pom.xml
@@ -144,6 +144,16 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ConnectorDefinitionResourceAssembler.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ConnectorDefinitionResourceAssembler.java
@@ -1,17 +1,15 @@
 package org.activiti.cloud.services.rest.assemblers;
 
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+
 import org.activiti.cloud.services.rest.controllers.ConnectorDefinitionControllerImpl;
 import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
 import org.activiti.core.common.model.connector.ConnectorDefinition;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceAssembler;
-import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
-
-@Component
 public class ConnectorDefinitionResourceAssembler implements ResourceAssembler<ConnectorDefinition, Resource<ConnectorDefinition>> {
 
     @Override

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessDefinitionMetaResourceAssembler.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/assemblers/ProcessDefinitionMetaResourceAssembler.java
@@ -1,5 +1,8 @@
 package org.activiti.cloud.services.rest.assemblers;
 
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+
 import org.activiti.cloud.services.api.model.ProcessDefinitionMeta;
 import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
 import org.activiti.cloud.services.rest.controllers.ProcessDefinitionControllerImpl;
@@ -8,12 +11,7 @@ import org.activiti.cloud.services.rest.controllers.ProcessInstanceControllerImp
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceAssembler;
-import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
-
-@Component
 public class ProcessDefinitionMetaResourceAssembler implements ResourceAssembler<ProcessDefinitionMeta, Resource<ProcessDefinitionMeta>> {
 
     @Override

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/conf/ServicesRestControllersAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/conf/ServicesRestControllersAutoConfiguration.java
@@ -1,0 +1,43 @@
+package org.activiti.cloud.services.rest.conf;
+
+import org.activiti.cloud.services.rest.controllers.ConnectorDefinitionControllerImpl;
+import org.activiti.cloud.services.rest.controllers.HomeControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessDefinitionAdminControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessDefinitionControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessDefinitionMetaControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessInstanceAdminControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessInstanceControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessInstanceTasksControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessInstanceVariableAdminControllerImpl;
+import org.activiti.cloud.services.rest.controllers.ProcessInstanceVariableControllerImpl;
+import org.activiti.cloud.services.rest.controllers.RuntimeBundleExceptionHandler;
+import org.activiti.cloud.services.rest.controllers.TaskAdminControllerImpl;
+import org.activiti.cloud.services.rest.controllers.TaskControllerImpl;
+import org.activiti.cloud.services.rest.controllers.TaskVariableAdminControllerImpl;
+import org.activiti.cloud.services.rest.controllers.TaskVariableControllerImpl;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@ConditionalOnWebApplication
+@AutoConfigureAfter(ServicesRestWebMvcAutoConfiguration.class)
+@Import({HomeControllerImpl.class,
+    ConnectorDefinitionControllerImpl.class,
+    ProcessDefinitionAdminControllerImpl.class,
+    ProcessDefinitionControllerImpl.class,
+    ProcessDefinitionMetaControllerImpl.class,
+    ProcessInstanceAdminControllerImpl.class,
+    ProcessInstanceControllerImpl.class,
+    ProcessInstanceTasksControllerImpl.class,
+    ProcessInstanceVariableAdminControllerImpl.class,
+    ProcessInstanceVariableControllerImpl.class,
+    RuntimeBundleExceptionHandler.class,
+    TaskAdminControllerImpl.class,
+    TaskControllerImpl.class,
+    TaskVariableAdminControllerImpl.class,
+    TaskVariableControllerImpl.class})
+public class ServicesRestControllersAutoConfiguration {
+
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/conf/ServicesRestWebMvcAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/java/org/activiti/cloud/services/rest/conf/ServicesRestWebMvcAutoConfiguration.java
@@ -16,10 +16,9 @@
 
 package org.activiti.cloud.services.rest.conf;
 
-import java.util.List;
-import java.util.Map;
-
 import org.activiti.cloud.services.events.converter.RuntimeBundleInfoAppender;
+import org.activiti.cloud.services.rest.assemblers.ConnectorDefinitionResourceAssembler;
+import org.activiti.cloud.services.rest.assemblers.ProcessDefinitionMetaResourceAssembler;
 import org.activiti.cloud.services.rest.assemblers.ProcessDefinitionResourceAssembler;
 import org.activiti.cloud.services.rest.assemblers.ProcessInstanceResourceAssembler;
 import org.activiti.cloud.services.rest.assemblers.ProcessInstanceVariableResourceAssembler;
@@ -47,13 +46,16 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+import java.util.Map;
+
 @Configuration
 @AutoConfigureAfter(WebMvcAutoConfiguration.class)
-public class ServicesRestAutoConfiguration implements WebMvcConfigurer {
+public class ServicesRestWebMvcAutoConfiguration implements WebMvcConfigurer {
 
     private final Jackson2ObjectMapperBuilder objectMapperBuilder;
 
-    public ServicesRestAutoConfiguration(Jackson2ObjectMapperBuilder objectMapperBuilder) {
+    public ServicesRestWebMvcAutoConfiguration(Jackson2ObjectMapperBuilder objectMapperBuilder) {
         this.objectMapperBuilder = objectMapperBuilder;
     }
 
@@ -61,7 +63,17 @@ public class ServicesRestAutoConfiguration implements WebMvcConfigurer {
     public ResourcesAssembler resourcesAssembler() {
         return new ResourcesAssembler();
     }
+    
+    @Bean
+    public ConnectorDefinitionResourceAssembler connectorDefinitionResourceAssembler() {
+        return new ConnectorDefinitionResourceAssembler();
+    }
 
+    @Bean
+    public ProcessDefinitionMetaResourceAssembler processDefinitionMetaResourceAssembler() {
+        return new ProcessDefinitionMetaResourceAssembler();
+    }
+    
     @Bean
     public ProcessInstanceResourceAssembler processInstanceResourceAssembler(RuntimeBundleInfoAppender runtimeBundleInfoAppender) {
         return new ProcessInstanceResourceAssembler(new ToCloudProcessInstanceConverter(runtimeBundleInfoAppender));

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration,\
-    org.activiti.core.common.spring.connector.autoconfigure.ConnectorAutoConfiguration
+    org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration,\
+    org.activiti.cloud.services.rest.conf.ServicesRestControllersAutoConfiguration

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/Application.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/Application.java
@@ -18,7 +18,6 @@ package org.activiti.cloud.services.rest;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @SpringBootApplication
 public class Application {

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ConnectorDefinitionControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ConnectorDefinitionControllerImplIT.java
@@ -16,27 +16,6 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.activiti.cloud.services.rest.assemblers.ConnectorDefinitionResourceAssembler;
-import org.activiti.core.common.model.connector.ConnectorDefinition;
-import org.activiti.core.common.spring.connector.autoconfigure.ConnectorAutoConfiguration;
-import org.activiti.runtime.api.conf.ConnectorsAutoConfiguration;
-import org.activiti.spring.process.ProcessExtensionService;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Import;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -45,11 +24,40 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.rest.assemblers.ConnectorDefinitionResourceAssembler;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
+import org.activiti.core.common.model.connector.ConnectorDefinition;
+import org.activiti.core.common.spring.connector.autoconfigure.ConnectorAutoConfiguration;
+import org.activiti.engine.RepositoryService;
+import org.activiti.runtime.api.conf.ConnectorsAutoConfiguration;
+import org.activiti.spring.process.ProcessExtensionService;
+import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(SpringRunner.class)
 @WebMvcTest(ConnectorDefinitionControllerImpl.class)
 @Import({ConnectorsAutoConfiguration.class,
-        ConnectorAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers"})
+        ConnectorAutoConfiguration.class,
+        ServicesRestWebMvcAutoConfiguration.class,
+        CloudEventsAutoConfiguration.class,
+        RuntimeBundleProperties.class,
+        ProcessExtensionsAutoConfiguration.class})
 public class ConnectorDefinitionControllerImplIT {
 
     private MockMvc mockMvc;
@@ -59,6 +67,12 @@ public class ConnectorDefinitionControllerImplIT {
 
     @MockBean
     private ProcessExtensionService processExtensionService;
+    
+    @MockBean 
+    private ProcessEngineChannels processEngineChannels;
+    
+    @MockBean
+    private RepositoryService repositoryService;
 
     @Before
     public void setup() {

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionAdminControllerImplIT.java
@@ -31,21 +31,21 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
+import org.activiti.engine.TaskService;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
 import org.junit.Before;
@@ -56,14 +56,18 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(value = ProcessDefinitionAdminControllerImpl.class)
@@ -73,9 +77,9 @@ import org.springframework.test.web.servlet.MvcResult;
 @Import({RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class,
-        ServicesCoreAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        ServicesCoreAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class ProcessDefinitionAdminControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "process-definition";
@@ -92,7 +96,19 @@ public class ProcessDefinitionAdminControllerImplIT {
     private ProcessAdminRuntime processAdminRuntime;
 
     @MockBean
+    private TaskAdminRuntime taskAdminRuntime;
+    
+    @MockBean
     private ProcessEngineChannels processEngineChannels;
+    
+    @MockBean
+    private TaskService taskService;
+
+    @MockBean
+    private SecurityManager securityManager;
+    
+    @MockBean
+    private MessageChannel commandResults;
 
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessDefinitionControllerImplIT.java
@@ -34,25 +34,22 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.Process;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.core.ProcessDiagramGeneratorWrapper;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.RepositoryService;
 import org.activiti.image.exception.ActivitiInterchangeInfoNotFoundException;
@@ -69,14 +66,20 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(value = ProcessDefinitionControllerImpl.class)
@@ -86,9 +89,9 @@ import org.springframework.test.web.servlet.MvcResult;
 @Import({RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class,
-        ServicesCoreAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        ServicesCoreAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 @EnableAutoConfiguration(exclude = { SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
 public class ProcessDefinitionControllerImplIT {
 
@@ -111,6 +114,15 @@ public class ProcessDefinitionControllerImplIT {
     @MockBean
     private ProcessRuntime processRuntime;
 
+    @MockBean
+    private TaskAdminRuntime taskAdminRuntime;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
+    
+    @MockBean
+    private MessageChannel commandResults;
+    
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceAdminControllerImplIT.java
@@ -34,9 +34,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.MessagePayloadBuilder;
@@ -46,12 +43,14 @@ import org.activiti.api.process.model.payloads.StartMessagePayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.core.conf.ServicesCoreAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -66,15 +65,18 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.util.Collections;
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ProcessInstanceAdminControllerImpl.class)
@@ -84,9 +86,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 @Import({RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class,
-        ServicesCoreAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        ServicesCoreAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 @EnableAutoConfiguration(exclude = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class})
 public class ProcessInstanceAdminControllerImplIT {
 
@@ -108,6 +110,12 @@ public class ProcessInstanceAdminControllerImplIT {
     
     @MockBean
     private ProcessAdminRuntime processAdminRuntime;
+    
+    @MockBean
+    private TaskAdminRuntime taskAdminRuntime;
+
+    @MockBean
+    private MessageChannel commandResults;
 
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceTasksControllerImplIT.java
@@ -16,38 +16,6 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.activiti.api.runtime.shared.query.Page;
-import org.activiti.api.task.model.Task;
-import org.activiti.api.task.runtime.TaskRuntime;
-import org.activiti.cloud.services.core.pageable.SpringPageConverter;
-import org.activiti.cloud.services.events.ProcessEngineChannels;
-import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
-import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
-import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
-import org.activiti.engine.RepositoryService;
-import org.activiti.runtime.api.query.impl.PageImpl;
-import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.web.config.EnableSpringDataWebSupport;
-import org.springframework.hateoas.MediaTypes;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pageRequestParameters;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.pagedResourcesResponseFields;
 import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.processInstanceIdParameter;
@@ -61,6 +29,41 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
+import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.task.model.Task;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.api.task.runtime.TaskRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
+import org.activiti.cloud.services.core.pageable.SpringPageConverter;
+import org.activiti.cloud.services.events.ProcessEngineChannels;
+import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
+import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
+import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
+import org.activiti.engine.RepositoryService;
+import org.activiti.runtime.api.query.impl.PageImpl;
+import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
 @RunWith(SpringRunner.class)
 @WebMvcTest(ProcessInstanceTasksControllerImpl.class)
 @EnableSpringDataWebSupport
@@ -69,8 +72,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import({RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class ProcessInstanceTasksControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "process-instance-tasks";
@@ -91,6 +94,15 @@ public class ProcessInstanceTasksControllerImplIT {
 
     @MockBean
     private ProcessEngineChannels processEngineChannels;
+    
+    @MockBean
+    private TaskAdminRuntime taskAdminRuntime;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
+    
+    @MockBean
+    private MessageChannel commandResults;
 
     @MockBean
     private CloudProcessDeployedProducer processDeployedProducer;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableAdminControllerImplIT.java
@@ -25,21 +25,19 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.conf.impl.ProcessModelAutoConfiguration;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
 import org.activiti.spring.process.model.ProcessExtensionModel;
@@ -51,16 +49,20 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ProcessInstanceVariableAdminControllerImpl.class)
@@ -72,8 +74,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
         RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class ProcessInstanceVariableAdminControllerImplIT {
 
     @Autowired
@@ -84,6 +86,12 @@ public class ProcessInstanceVariableAdminControllerImplIT {
 
     @MockBean
     private Map<String, ProcessExtensionModel> processExtensionModelMap;
+    
+    @MockBean
+    private TaskAdminRuntime taskAdminRuntime;
+
+    @MockBean
+    private MessageChannel commandResults;
     
     @MockBean
     private ProcessVariablesPayloadValidator processVariablesValidator;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessInstanceVariableControllerImplIT.java
@@ -30,23 +30,21 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.conf.impl.ProcessModelAutoConfiguration;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
+import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.spring.process.variable.DateFormatterProvider;
 import org.activiti.spring.process.variable.VariableValidationService;
@@ -59,13 +57,18 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ProcessInstanceVariableControllerImpl.class)
@@ -77,8 +80,8 @@ import org.springframework.test.web.servlet.MockMvc;
         RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         VariableValidationService.class,
-        ServicesRestAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class ProcessInstanceVariableControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "process-instance-variables";
@@ -92,6 +95,15 @@ public class ProcessInstanceVariableControllerImplIT {
     
     @MockBean
     private RepositoryService repositoryService;
+    
+    @MockBean
+    private TaskAdminRuntime taskAdminRuntime;
+
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
+    
+    @MockBean
+    private MessageChannel commandResults;
     
     @MockBean
     private DateFormatterProvider dateFormatterProvider;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessVariablesPayloadValidatorIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/ProcessVariablesPayloadValidatorIT.java
@@ -21,16 +21,14 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.conf.impl.ProcessModelAutoConfiguration;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
 import org.activiti.spring.process.model.Extension;
@@ -46,10 +44,12 @@ import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDoc
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ProcessVariablesPayloadValidator.class)
@@ -61,8 +61,8 @@ import org.springframework.test.context.junit4.SpringRunner;
         RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class ProcessVariablesPayloadValidatorIT {
     @MockBean
     private ProcessEngineChannels processEngineChannels;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskAdminControllerImplIT.java
@@ -34,21 +34,19 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.model.payloads.UpdateTaskPayload;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -61,13 +59,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = TaskAdminControllerImpl.class, secure = true)
@@ -78,8 +78,8 @@ import org.springframework.test.web.servlet.MockMvc;
         CloudEventsAutoConfiguration.class,
         TaskSamples.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class TaskAdminControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "task-admin";

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskControllerImplIT.java
@@ -43,11 +43,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.shared.NotFoundException;
@@ -61,12 +56,13 @@ import org.activiti.api.task.model.payloads.CreateTaskPayload;
 import org.activiti.api.task.model.payloads.SaveTaskPayload;
 import org.activiti.api.task.model.payloads.UpdateTaskPayload;
 import org.activiti.api.task.runtime.TaskRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.core.pageable.SpringPageConverter;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
@@ -80,13 +76,17 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = TaskControllerImpl.class, secure = false)
@@ -99,8 +99,8 @@ import org.springframework.test.web.servlet.MockMvc;
         RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
-@ComponentScan(basePackages = {"org.activiti.cloud.services.rest.assemblers", "org.activiti.cloud.alfresco"})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class TaskControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "task";

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableAdminControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableAdminControllerImplIT.java
@@ -16,21 +16,35 @@
 
 package org.activiti.cloud.services.rest.controllers;
 
-import java.util.Arrays;
-import java.util.UUID;
+import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.taskIdParameter;
+import static org.activiti.alfresco.rest.docs.HALDocumentation.unpagedVariableFields;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.runtime.conf.impl.CommonModelAutoConfiguration;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.api.task.conf.impl.TaskModelAutoConfiguration;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.runtime.TaskAdminRuntime;
+import org.activiti.cloud.alfresco.config.AlfrescoWebAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfiguration;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.assemblers.TaskVariableInstanceResourceAssembler;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
 import org.junit.Before;
@@ -49,20 +63,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.activiti.alfresco.rest.docs.AlfrescoDocumentation.taskIdParameter;
-import static org.activiti.alfresco.rest.docs.HALDocumentation.unpagedVariableFields;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.Arrays;
+import java.util.UUID;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(controllers = TaskVariableAdminControllerImpl.class, secure = false)
@@ -74,7 +76,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
+        ServicesRestWebMvcAutoConfiguration.class,
+        AlfrescoWebAutoConfiguration.class})
 public class TaskVariableAdminControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "task-variable";
@@ -91,6 +94,9 @@ public class TaskVariableAdminControllerImplIT {
     @MockBean
     private TaskAdminRuntime taskRuntime;
 
+    @MockBean
+    private ProcessAdminRuntime processAdminRuntime;
+    
     @SpyBean
     private TaskVariableInstanceResourceAssembler variableInstanceResourceAssembler;
 

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-rest-impl/src/test/java/org/activiti/cloud/services/rest/controllers/TaskVariableControllerImplIT.java
@@ -30,7 +30,7 @@ import org.activiti.cloud.services.events.configuration.CloudEventsAutoConfigura
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.listeners.CloudProcessDeployedProducer;
 import org.activiti.cloud.services.rest.assemblers.TaskVariableInstanceResourceAssembler;
-import org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration;
+import org.activiti.cloud.services.rest.conf.ServicesRestWebMvcAutoConfiguration;
 import org.activiti.engine.RepositoryService;
 import org.activiti.spring.process.conf.ProcessExtensionsAutoConfiguration;
 import org.junit.Before;
@@ -74,7 +74,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         RuntimeBundleProperties.class,
         CloudEventsAutoConfiguration.class,
         ProcessExtensionsAutoConfiguration.class,
-        ServicesRestAutoConfiguration.class})
+        ServicesRestWebMvcAutoConfiguration.class})
 public class TaskVariableControllerImplIT {
 
     private static final String DOCUMENTATION_IDENTIFIER = "task-variable";

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/SignalSender.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/SignalSender.java
@@ -5,7 +5,6 @@ import org.activiti.runtime.api.signal.SignalPayloadEventListener;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -13,7 +12,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
  * Overrides default SignalPayloadEventListener implementation to 
  * broadcast signals into Runtime Bundle instances via Cloud Stream
  */
-@Component
 public class SignalSender implements SignalPayloadEventListener {
 
     private final BinderAwareChannelResolver resolver;

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/channel/BroadcastSignalEventHandler.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/channel/BroadcastSignalEventHandler.java
@@ -2,20 +2,14 @@ package org.activiti.services.subscription.channel;
 
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.engine.RuntimeService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
-import org.springframework.stereotype.Component;
 
-@Component
-@EnableBinding(ProcessEngineSignalChannels.class)
-public class BroadcastSignaEventHandler {
+public class BroadcastSignalEventHandler {
 
     private final RuntimeService runtimeService;
 
-    @Autowired
-    public BroadcastSignaEventHandler(BinderAwareChannelResolver resolver,
+    public BroadcastSignalEventHandler(BinderAwareChannelResolver resolver,
                                       RuntimeService runtimeService) {
         this.runtimeService = runtimeService;
     }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/config/ActivitiCloudSubscriptionsAutoConfiguration.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscription/config/ActivitiCloudSubscriptionsAutoConfiguration.java
@@ -1,0 +1,55 @@
+package org.activiti.services.subscription.config;
+
+import static org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME;
+
+import org.activiti.bpmn.model.Signal;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.engine.RuntimeService;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
+import org.activiti.runtime.api.conf.ProcessRuntimeAutoConfiguration;
+import org.activiti.runtime.api.signal.SignalPayloadEventListener;
+import org.activiti.services.subscription.SignalSender;
+import org.activiti.services.subscription.channel.BroadcastSignalEventHandler;
+import org.activiti.services.subscription.channel.ProcessEngineSignalChannels;
+import org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+
+@Configuration
+@EnableBinding(ProcessEngineSignalChannels.class)
+@AutoConfigureBefore({ProcessRuntimeAutoConfiguration.class})
+public class ActivitiCloudSubscriptionsAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public BroadcastSignalEventHandler broadcastSignalEventHandler(BinderAwareChannelResolver resolver,
+                                                                  RuntimeService runtimeService) {
+        return new BroadcastSignalEventHandler(resolver,
+                                              runtimeService);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SignalPayloadEventListener signalSender(BinderAwareChannelResolver resolver) {
+        return new SignalSender(resolver);
+    }
+
+    @Bean(DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME)
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    @ConditionalOnMissingBean
+    public IntermediateThrowSignalEventActivityBehavior broadcastSignalEventActivityBehavior(ApplicationEventPublisher eventPublisher,
+                                                                                     SignalEventDefinition signalEventDefinition,
+                                                                                     Signal signal) {
+        return new BroadcastSignalEventActivityBehavior(eventPublisher,
+                                                        signalEventDefinition,
+                                                        signal);
+    }
+
+}

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscriptions/behavior/BroadcastSignalEventActivityBehavior.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/java/org/activiti/services/subscriptions/behavior/BroadcastSignalEventActivityBehavior.java
@@ -8,16 +8,9 @@ import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
-import static org.activiti.services.subscriptions.behavior.BroadcastSignalEventActivityBehavior.DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME;
-
-@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-@Component(DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME)
 public class BroadcastSignalEventActivityBehavior extends IntermediateThrowSignalEventActivityBehavior {
 
     public static final String DEFAULT_THROW_SIGNAL_EVENT_BEAN_NAME = "defaultThrowSignalEventBehavior";

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-subscriptions/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.cloud.services.rest.conf.ServicesRestAutoConfiguration,\
-    org.activiti.core.common.spring.connector.autoconfigure.ConnectorAutoConfiguration
+	org.activiti.services.subscription.config.ActivitiCloudSubscriptionsAutoConfiguration

--- a/activiti-cloud-starter-runtime-bundle/pom.xml
+++ b/activiti-cloud-starter-runtime-bundle/pom.xml
@@ -98,6 +98,10 @@
       <artifactId>spring-boot-starter-hateoas</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.hateoas</groupId>
       <artifactId>spring-hateoas</artifactId>
     </dependency>

--- a/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiRuntimeBundle.java
+++ b/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiRuntimeBundle.java
@@ -1,12 +1,5 @@
 package org.activiti.cloud.starter.rb.configuration;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import org.activiti.cloud.services.common.security.keycloak.config.CommonSecurityAutoConfiguration;
 import org.activiti.cloud.services.events.ProcessEngineChannels;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
@@ -15,13 +8,19 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @EnableBinding(ProcessEngineChannels.class)
 @Inherited
 @EnableDiscoveryClient
 @EnableWebSecurity
-@EnableAutoConfiguration(exclude = {CommonSecurityAutoConfiguration.class,TaskExecutionAutoConfiguration.class, TaskSchedulingAutoConfiguration.class})
+@EnableAutoConfiguration(exclude = {TaskExecutionAutoConfiguration.class, TaskSchedulingAutoConfiguration.class})
 public @interface ActivitiRuntimeBundle {
 
 }

--- a/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiRuntimeBundleAutoConfiguration.java
+++ b/activiti-cloud-starter-runtime-bundle/src/main/java/org/activiti/cloud/starter/rb/configuration/ActivitiRuntimeBundleAutoConfiguration.java
@@ -1,15 +1,9 @@
 package org.activiti.cloud.starter.rb.configuration;
 
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration
-@ComponentScan({"org.activiti.cloud.services",
-        "org.activiti.cloud.alfresco",
-        "org.activiti.core.common.spring.security.policies",
-        "org.activiti.cloud.services.common.security",
-        "org.activiti.cloud.services.identity"})
 @Import(SwaggerConfig.class)
 public class ActivitiRuntimeBundleAutoConfiguration {
 

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/Application.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/Application.java
@@ -16,17 +16,14 @@
 
 package org.activiti.cloud.starter.tests;
 
-import org.activiti.cloud.services.common.security.keycloak.config.CommonSecurityAutoConfiguration;
 import org.activiti.cloud.starter.rb.configuration.ActivitiRuntimeBundle;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
-@SpringBootApplication(exclude = {CommonSecurityAutoConfiguration.class})
+@SpringBootApplication
 @ActivitiRuntimeBundle
-@ComponentScan({"org.activiti.cloud.starters.test",
-        "org.activiti.cloud.services.test.identity.keycloak.interceptor"})
-
+//@ComponentScan({"org.activiti.cloud.starters.test",
+//                "org.activiti.cloud.services.test.identity.keycloak.interceptor"})
 public class Application {
 
     public static void main(String[] args) {

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/RbTestApplication.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/RbTestApplication.java
@@ -22,12 +22,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @ActivitiRuntimeBundle
-//@ComponentScan({"org.activiti.cloud.starters.test",
-//                "org.activiti.cloud.services.test.identity.keycloak.interceptor"})
-public class Application {
+public class RbTestApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
+        SpringApplication.run(RbTestApplication.class, args);
     }
 
 }

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndPointITStreamHandler.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndPointITStreamHandler.java
@@ -1,6 +1,6 @@
 package org.activiti.cloud.starter.tests.cmdendpoint;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.api.model.shared.Result;
 import org.activiti.api.process.model.ProcessInstance;
@@ -15,15 +15,15 @@ import org.activiti.api.task.model.payloads.CompleteTaskPayload;
 import org.activiti.api.task.model.payloads.CreateTaskVariablePayload;
 import org.activiti.api.task.model.payloads.ReleaseTaskPayload;
 import org.activiti.api.task.model.payloads.UpdateTaskVariablePayload;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Profile(CommandEndPointITStreamHandler.COMMAND_ENDPOINT_IT)
-@Component
+@TestComponent
 @EnableBinding(MessageClientStream.class)
 public class CommandEndPointITStreamHandler {
 

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/cmdendpoint/CommandEndpointIT.java
@@ -24,11 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
@@ -56,6 +51,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resources;
@@ -68,11 +64,19 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 @RunWith(SpringRunner.class)
 @ActiveProfiles(CommandEndPointITStreamHandler.COMMAND_ENDPOINT_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import({CommandEndPointITStreamHandler.class,
+        ProcessInstanceRestTemplate.class,
+        TaskRestTemplate.class})
 public class CommandEndpointIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/definition/ProcessDefinitionIT.java
@@ -18,10 +18,6 @@ package org.activiti.cloud.starter.tests.definition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Iterator;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.bpmn.converter.BpmnXMLConverter;
@@ -49,6 +45,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Iterator;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/HelperConfiguration.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/helper/HelperConfiguration.java
@@ -1,0 +1,14 @@
+package org.activiti.cloud.starter.tests.helper;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import({ProcessInstanceRestTemplate.class,
+        TaskRestTemplate.class,
+        MessageRestTemplate.class,
+        ProcessDefinitionRestTemplate.class,
+        SignalRestTemplate.class})
+public class HelperConfiguration {
+
+}

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/JobExecutorIT.java
@@ -25,12 +25,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.activiti.cloud.services.events.message.RuntimeBundleInfoMessageHeaders;
 import org.activiti.cloud.services.job.executor.JobMessageFailedEvent;
@@ -82,12 +76,19 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(JobExecutorIT.JOB_EXECUTOR_IT)
@@ -97,6 +98,8 @@ import org.springframework.transaction.support.TransactionTemplate;
         "spring.activiti.cloud.rb.job-executor.message-job-consumer.max-attempts=4" // customized
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = {RuntimeITConfiguration.class, 
+                                JobExecutorIT.JobExecutorITProcessEngineConfigurer.class})
 public class JobExecutorIT {
     private static final Logger logger = LoggerFactory.getLogger(JobExecutorIT.class);
     public static final String JOB_EXECUTOR_IT = "JobExecutorIT";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MQServiceTaskIT.java
@@ -20,11 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
@@ -48,13 +43,20 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resources;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class MQServiceTaskIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/MessageIT.java
@@ -32,6 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -39,6 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class MessageIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessInstanceIT.java
@@ -16,6 +16,9 @@
 
 package org.activiti.cloud.starter.tests.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -43,20 +46,23 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class ProcessInstanceIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ProcessVariablesIT.java
@@ -16,17 +16,9 @@
 
 package org.activiti.cloud.starter.tests.runtime;
 
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.model.shared.model.VariableInstance;
@@ -50,17 +42,27 @@ import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-import static org.awaitility.Awaitility.await;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class ProcessVariablesIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/RuntimeITConfiguration.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/RuntimeITConfiguration.java
@@ -1,0 +1,14 @@
+package org.activiti.cloud.starter.tests.runtime;
+
+import org.activiti.cloud.starter.tests.helper.HelperConfiguration;
+import org.activiti.cloud.starter.tests.util.VariablesUtil;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import({HelperConfiguration.class,
+        ServiceTaskConsumerHandler.class,
+        VariablesUtil.class})
+public class RuntimeITConfiguration {
+
+}

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/ServiceTaskConsumerHandler.java
@@ -19,9 +19,6 @@ package org.activiti.cloud.starter.tests.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.cloud.api.process.model.IntegrationRequest;
@@ -29,15 +26,18 @@ import org.activiti.cloud.api.process.model.impl.IntegrationResultImpl;
 import org.activiti.cloud.services.events.configuration.RuntimeBundleProperties;
 import org.assertj.core.api.Assertions;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.cloud.stream.annotation.StreamListener;
 import org.springframework.cloud.stream.binding.BinderAwareChannelResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
+import java.util.HashMap;
+import java.util.Map;
+
+@TestComponent
 @EnableBinding(ConnectorIntegrationChannels.class)
 public class ServiceTaskConsumerHandler {
 

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/SignalIT.java
@@ -20,11 +20,6 @@ import static org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplat
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -52,13 +47,21 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class SignalIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariableMappingIT.java
@@ -20,10 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.task.model.Task.TaskStatus;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
@@ -45,13 +41,19 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resources;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application-test.properties")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class TaskVariableMappingIT {
     
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TaskVariablesIT.java
@@ -18,12 +18,6 @@ package org.activiti.cloud.starter.tests.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.cloud.api.model.shared.CloudVariableInstance;
@@ -48,13 +42,21 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class TaskVariablesIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/runtime/TasksIT.java
@@ -16,12 +16,8 @@
 
 package org.activiti.cloud.starter.tests.runtime;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.task.model.Task;
@@ -52,15 +48,22 @@ import org.springframework.hateoas.Resources;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.assertj.core.api.Assertions.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource({"classpath:application-test.properties", "classpath:access-control.properties"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = RuntimeITConfiguration.class)
 public class TasksIT {
 
     private static final String SIMPLE_PROCESS = "SimpleProcess";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditConsumerStreamHandler.java
@@ -16,6 +16,15 @@
 
 package org.activiti.cloud.starter.tests.services.audit;
 
+import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.AUDIT_PRODUCER_IT;
+
+import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.handler.annotation.Headers;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -23,17 +32,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
-import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.annotation.StreamListener;
-import org.springframework.context.annotation.Profile;
-import org.springframework.messaging.handler.annotation.Headers;
-import org.springframework.stereotype.Component;
-
-import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.AUDIT_PRODUCER_IT;
-
 @Profile(AUDIT_PRODUCER_IT)
-@Component
+@TestComponent
 @EnableBinding(AuditConsumer.class)
 public class AuditConsumerStreamHandler {
 

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -28,14 +28,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
@@ -56,7 +48,6 @@ import org.activiti.cloud.api.task.model.events.CloudTaskCandidateUserRemovedEve
 import org.activiti.cloud.starter.tests.helper.ProcessInstanceRestTemplate;
 import org.activiti.cloud.starter.tests.helper.TaskRestTemplate;
 import org.activiti.engine.RuntimeService;
-import org.awaitility.Duration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,14 +62,24 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class AuditProducerIT {
 
     private static final String SIMPLE_SUB_PROCESS1 = "simpleSubProcess1";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/EmbeddedSubProcessAuditIT.java
@@ -19,10 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.SignalPayload;
@@ -54,14 +50,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class EmbeddedSubProcessAuditIT {
 
     private static final String SIMPLE_SUB_PROCESS1 = "simpleSubProcess1";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ErrorAuditProducerIT.java
@@ -25,8 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
-
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.BPMNError;
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
@@ -43,14 +41,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class ErrorAuditProducerIT {
 
     private static final String ERROR_START_EVENT_SUBPROCESS = "errorStartEventSubProcess";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ExclusiveGatewayAuditProducerIT.java
@@ -20,23 +20,19 @@ import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.V
 import static org.activiti.api.model.shared.event.VariableEvent.VariableEvents.VARIABLE_UPDATED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED;
 import static org.activiti.api.process.model.events.BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED;
+import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED;
 import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_CREATED;
 import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED;
-import static org.activiti.api.process.model.events.ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED;
 import static org.activiti.api.process.model.events.SequenceFlowEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN;
 import static org.activiti.api.task.model.events.TaskCandidateUserEvent.TaskCandidateUserEvents.TASK_CANDIDATE_USER_ADDED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED;
+import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_COMPLETED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_CREATED;
 import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_UPDATED;
-import static org.activiti.api.task.model.events.TaskRuntimeEvent.TaskEvents.TASK_COMPLETED;
 import static org.activiti.cloud.starter.tests.services.audit.AuditProducerIT.ALL_REQUIRED_HEADERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.BPMNActivity;
@@ -59,14 +55,20 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class ExclusiveGatewayAuditProducerIT {
 
     private static final String EXCLUSIVE_GATEWAY_PROCESS = "basicExclusiveGateway";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/InclusiveGatewayAuditProducerIT.java
@@ -31,9 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Iterator;
-import java.util.List;
-
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
 import org.activiti.api.task.model.Task.TaskStatus;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
@@ -50,14 +47,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Iterator;
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class InclusiveGatewayAuditProducerIT {
 
     private static final String INCLUSIVE_GATEWAY_PROCESS = "basicInclusiveGateway";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/MessageAuditProducerIT.java
@@ -27,9 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.activiti.api.process.model.BPMNMessage;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.activiti.cloud.api.process.model.CloudProcessInstance;
@@ -45,14 +42,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Collections;
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class MessageAuditProducerIT {
 
     @Autowired

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ParallelGatewayAuditProducerIT.java
@@ -27,8 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.List;
-
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
@@ -41,14 +39,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.List;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles(AuditProducerIT.AUDIT_PRODUCER_IT)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class ParallelGatewayAuditProducerIT {
 
     private static final String PARALLEL_GATEWAY_PROCESS = "basicParallelGateway";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ServicesAuditITConfiguration.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/ServicesAuditITConfiguration.java
@@ -1,0 +1,12 @@
+package org.activiti.cloud.starter.tests.services.audit;
+
+import org.activiti.cloud.starter.tests.helper.HelperConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+
+@TestConfiguration
+@Import({HelperConfiguration.class,
+        AuditConsumerStreamHandler.class})
+public class ServicesAuditITConfiguration {
+
+}

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/SignalAuditProducerIT.java
@@ -47,6 +47,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -61,6 +62,7 @@ import java.util.stream.Collectors;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = ServicesAuditITConfiguration.class)
 public class SignalAuditProducerIT {
 
     private static final String SIGNAL_PROCESS = "broadcastSignalCatchEventProcess";

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/TimerAuditProducerIT.java
@@ -24,11 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.activiti.api.process.model.builders.StartProcessPayloadBuilder;
 import org.activiti.api.process.model.events.BPMNTimerEvent;
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
@@ -59,14 +54,22 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles({AuditProducerIT.AUDIT_PRODUCER_IT, TimerAuditProducerIT.TIMER_AUDIT_PRODUCER_IT})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource("classpath:application-test.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ContextConfiguration(classes = {ServicesAuditITConfiguration.class, 
+                                TimerAuditProducerIT.JobExecutorITProcessEngineConfigurer.class})
 public class TimerAuditProducerIT {
 
     public static final String TIMER_AUDIT_PRODUCER_IT = "TimerAuditProducerIT";

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <activiti-dependencies.version>7.1.79</activiti-dependencies.version>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
-    <activiti-cloud-service-common.version>7.1.67</activiti-cloud-service-common.version>
+    <activiti-cloud-service-common.version>7.1.68</activiti-cloud-service-common.version>
     <activiti-cloud-runtime-bundle-service.version>${project.version}</activiti-cloud-runtime-bundle-service.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <url>http://activiti.org</url>
 
   <properties>
-    <activiti-dependencies.version>7.1.78</activiti-dependencies.version>
+    <activiti-dependencies.version>7.1.79</activiti-dependencies.version>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>7.1.67</activiti-cloud-service-common.version>
     <activiti-cloud-runtime-bundle-service.version>${project.version}</activiti-cloud-runtime-bundle-service.version>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/Activiti/pull/2904 and https://github.com/Activiti/activiti-cloud-service-common/pull/207

Fixes https://github.com/Activiti/Activiti/issues/1399