### PR TITLE
fix(AAE-731): Added root execution context message headers support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,7 @@ pipeline {
           branch 'PR-*'
         }
         environment {
-          PROJECT_VERSION = maven_project_version()
-          PREVIEW_VERSION = "$PROJECT_VERSION".replaceAll("SNAPSHOT","$BRANCH_NAME-$BUILD_NUMBER-SNAPSHOT")
+          PREVIEW_VERSION = maven_project_version().replaceAll("SNAPSHOT","$BRANCH_NAME-$BUILD_NUMBER-SNAPSHOT")
           PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
           HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
         }

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListener.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/MessageProducerCommandContextCloseListener.java
@@ -31,8 +31,9 @@ import org.springframework.util.Assert;
 
 public class MessageProducerCommandContextCloseListener implements CommandContextCloseListener {
 
+    public static final String ROOT_EXECUTION_CONTEXT = "rootExecutionContext";
     public static final String PROCESS_ENGINE_EVENTS = "processEngineEvents";
-
+    
     private final ProcessEngineChannels producer;
     private final MessageBuilderChainFactory<ExecutionContext> messageBuilderChainFactory;
     private final RuntimeBundleInfoAppender runtimeBundleInfoAppender;
@@ -57,6 +58,7 @@ public class MessageProducerCommandContextCloseListener implements CommandContex
         List<CloudRuntimeEvent<?, ?>> events = commandContext.getGenericAttribute(PROCESS_ENGINE_EVENTS);
         
         if (events != null && !events.isEmpty()) {
+            ExecutionContext rootExecutionContext = commandContext.getGenericAttribute(ROOT_EXECUTION_CONTEXT);
 
             // Add runtime bundle context attributes to every event 
             CloudRuntimeEvent<?, ?>[] payload = events.stream()
@@ -65,8 +67,9 @@ public class MessageProducerCommandContextCloseListener implements CommandContex
                                                       .map(runtimeBundleInfoAppender::appendRuntimeBundleInfoTo)
                                                       .toArray(CloudRuntimeEvent<?, ?>[]::new);
 
-            // Inject message headers with null execution context as there may be events from several process instances
-            Message<CloudRuntimeEvent<?, ?>[]> message = messageBuilderChainFactory.create(null)
+            
+            // Inject message headers with root execution context as there may be events from several process instances
+            Message<CloudRuntimeEvent<?, ?>[]> message = messageBuilderChainFactory.create(rootExecutionContext)
                                                                                    .withPayload(payload)
                                                                                    .build();
             // Send message to audit producer channel

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/ProcessEngineEventsAggregator.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/ProcessEngineEventsAggregator.java
@@ -16,6 +16,8 @@
 
 package org.activiti.cloud.services.events.listeners;
 
+import static org.activiti.cloud.services.events.listeners.MessageProducerCommandContextCloseListener.ROOT_EXECUTION_CONTEXT;
+
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.BPMNActivity;
 import org.activiti.api.process.model.BPMNSequenceFlow;
@@ -98,6 +100,9 @@ public class ProcessEngineEventsAggregator extends BaseCommandContextEventsAggre
             if (executionEntity != null) {
                 commandContext.addAttribute(executionId,
                                             executionContext);
+                
+                mayBeAddRootExecutionContext(commandContext, 
+                                             executionEntity);
             }
         }
         
@@ -105,6 +110,20 @@ public class ProcessEngineEventsAggregator extends BaseCommandContextEventsAggre
        
     }
     
+    protected void mayBeAddRootExecutionContext(CommandContext commandContext, ExecutionEntity executionEntity) {
+        ExecutionContext rootExecutionContext = commandContext.getGenericAttribute(ROOT_EXECUTION_CONTEXT);
+        
+        if(rootExecutionContext == null && executionEntity.getRootProcessInstanceId() != null) {
+            ExecutionEntity rootProcessInstance = commandContext.getExecutionEntityManager()
+                                                                .findById(executionEntity.getRootProcessInstanceId());
+            
+            rootExecutionContext = createExecutionContext(rootProcessInstance);
+
+            commandContext.addAttribute("rootExecutionContext",
+                                        rootExecutionContext);
+        }
+    }
+
     
     protected ExecutionContextInfoAppender createExecutionContextInfoAppender(ExecutionContext executionContext) {
         return new ExecutionContextInfoAppender(executionContext);
@@ -132,8 +151,7 @@ public class ProcessEngineEventsAggregator extends BaseCommandContextEventsAggre
         } else if(element instanceof CloudTaskCandidateGroupEvent) {
             return ((CloudTaskCandidateGroupEvent) element).getProcessInstanceId();
         } else if(element instanceof CloudBPMNSignalEvent) {
-            return ((CloudBPMNSignalEvent) element).getEntity().getProcessInstanceId();
-        } else if(element instanceof CloudBPMNTimerEvent) {
+            return ((CloudBPMNSignalEvent) element).getEntity().getProcessInstanceId();        } else if(element instanceof CloudBPMNTimerEvent) {
             return ((CloudBPMNTimerEvent) element).getEntity().getProcessInstanceId();
         } else if(element instanceof CloudBPMNMessageEvent) {
             return ((CloudBPMNMessageEvent) element).getEntity().getProcessInstanceId();

--- a/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/ProcessEngineEventsAggregator.java
+++ b/activiti-cloud-services-runtime-bundle/activiti-cloud-services-events/src/main/java/org/activiti/cloud/services/events/listeners/ProcessEngineEventsAggregator.java
@@ -94,15 +94,15 @@ public class ProcessEngineEventsAggregator extends BaseCommandContextEventsAggre
         if(executionId != null && commandContext.getGenericAttribute(executionId) == null) {
             ExecutionEntity executionEntity = commandContext.getExecutionEntityManager()
                                                             .findById(executionId);
+
+            mayBeAddRootExecutionContext(commandContext, 
+                                         executionEntity);
             
             ExecutionContext executionContext = createExecutionContext(executionEntity);
             
             if (executionEntity != null) {
                 commandContext.addAttribute(executionId,
                                             executionContext);
-                
-                mayBeAddRootExecutionContext(commandContext, 
-                                             executionEntity);
             }
         }
         
@@ -151,7 +151,8 @@ public class ProcessEngineEventsAggregator extends BaseCommandContextEventsAggre
         } else if(element instanceof CloudTaskCandidateGroupEvent) {
             return ((CloudTaskCandidateGroupEvent) element).getProcessInstanceId();
         } else if(element instanceof CloudBPMNSignalEvent) {
-            return ((CloudBPMNSignalEvent) element).getEntity().getProcessInstanceId();        } else if(element instanceof CloudBPMNTimerEvent) {
+            return ((CloudBPMNSignalEvent) element).getEntity().getProcessInstanceId();        
+        } else if(element instanceof CloudBPMNTimerEvent) {
             return ((CloudBPMNTimerEvent) element).getEntity().getProcessInstanceId();
         } else if(element instanceof CloudBPMNMessageEvent) {
             return ((CloudBPMNMessageEvent) element).getEntity().getProcessInstanceId();

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -101,7 +101,10 @@ public class AuditProducerIT {
 
     public static final String ROUTING_KEY_HEADER = "routingKey";
     public static final String[] RUNTIME_BUNDLE_INFO_HEADERS = {"appName", "serviceName", "serviceVersion", "serviceFullName", ROUTING_KEY_HEADER};
-    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS)
+    public static final String[] REQIURED_EXECUTION_CONTEXT_HEADERS = {"processInstanceId", "processDefinitionId", "processDefinitionKey", "processDefinitionVersion", "deploymentId", "deploymentName", "appVersion"};
+    public static final String[] OPTIONAL_EXECUTION_CONTEXT_HEADERS = {"businessKey", "processName", "processDefinitionName"};
+    
+    public static final String[] ALL_REQUIRED_HEADERS = Stream.of(RUNTIME_BUNDLE_INFO_HEADERS, REQIURED_EXECUTION_CONTEXT_HEADERS)
             .flatMap(Stream::of)
             .toArray(String[]::new);
 
@@ -185,6 +188,7 @@ public class AuditProducerIT {
             List<CloudRuntimeEvent<?, ?>> receivedEvents = streamHandler.getLatestReceivedEvents();
 
             assertThat(streamHandler.getReceivedHeaders()).containsKeys(ALL_REQUIRED_HEADERS);
+            assertThat(streamHandler.getReceivedHeaders()).containsKeys(OPTIONAL_EXECUTION_CONTEXT_HEADERS);
 
             assertThat(receivedEvents)
                     .extracting(event -> event.getEventType().name())


### PR DESCRIPTION
This PR adds support for injecting root execution context attributes into engine events message headers to enable support for Spring Cloud Stream partitioned query and audit consumers with consistent message routing between partitions using process instance ids hash values , i.e.

```
# split engine events stream to 10 partitions
spring.cloud.stream.bindings.auditProducer.producer.partition-count=10

# Use processInstanceId header to route message between partitions or use random hash value if missing
spring.cloud.stream.bindings.auditProducer.producer.partition-key-expression=headers['processInstanceId']?:T(java.lang.Math).random()*100
```
