### PR TITLE
fix: Extracted external dependencies to root pom dependency management

### DIFF
--- a/activiti-cloud-runtime-bundle-dependencies/pom.xml
+++ b/activiti-cloud-runtime-bundle-dependencies/pom.xml
@@ -13,20 +13,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.cloud.common</groupId>
-        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
-        <version>${activiti-cloud-service-common.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.dependencies</groupId>
-        <artifactId>activiti-dependencies</artifactId>
-        <version>${activiti-dependencies.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.rb</groupId>
         <artifactId>activiti-cloud-services-api</artifactId>
         <version>${activiti-cloud-runtime-bundle-service.version}</version>

--- a/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
+++ b/activiti-cloud-starter-runtime-bundle/src/test/java/org/activiti/cloud/starter/tests/services/audit/AuditProducerIT.java
@@ -877,6 +877,7 @@ public class AuditProducerIT {
 
             List<CloudRuntimeEvent<?, ?>> applicationElementEvents = receivedEvents
                     .stream()
+                    .filter(event -> startProcessEntity.getBody().getId().equals(event.getProcessInstanceId()))
                     .filter(event -> event.getEntity().getClass().getSuperclass().equals(ApplicationElementImpl.class))
                     .collect(Collectors.toList());
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <module>activiti-cloud-starter-runtime-bundle-it</module>
   </modules>
   <properties>
-	  <project.scm.repository>activiti-cloud-runtime-bundle-service</project.scm.repository>
+	<project.scm.repository>activiti-cloud-runtime-bundle-service</project.scm.repository>
     <activiti-dependencies.version>7.1.181</activiti-dependencies.version>
     <activiti-cloud-build.version>7.1.30</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>7.1.151</activiti-cloud-service-common.version>
@@ -35,6 +35,20 @@
         <version>${activiti-cloud-build.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
+        <version>${activiti-cloud-service-common.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.dependencies</groupId>
+        <artifactId>activiti-dependencies</artifactId>
+        <version>${activiti-dependencies.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR fixes activiti-cloud-runtime-bundle-dependencies management BoM to extract external dependencies BoMs into root pom dependency management section

Part of https://github.com/Activiti/Activiti/issues/3099